### PR TITLE
Update api and add api update logic

### DIFF
--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -1,0 +1,41 @@
+name: "Called update for API change"
+on:
+  repository_dispatch:
+    types: ["api_update"]
+jobs:
+  test:
+    name: "Create PR for API update"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - name: "Update Buf Script"
+        id: buf-update
+        uses: authzed/actions/buf-api-update@main
+        with:
+          api-commit: "${{ github.event.client_payload.BUFTAG }}"
+          spec-path: buf.gen.yaml
+          file-format: "buf-gen-yaml"
+      - name: "Output update status"
+        env:
+          UPDATED_STATUS: ${{ steps.buf-update.outputs.updated }}
+        run: |
+          echo "Update status: $UPDATED_STATUS"
+      - name: "Install buf"
+        uses: "bufbuild/buf-setup-action@v1.43.0"
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.buf-update.outputs.updated == 'true'
+      - name: "Run buf generate"
+        if: steps.buf-update.outputs.updated == 'true'
+        run: "buf generate"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7.0.5
+        if: steps.buf-update.outputs.updated == 'true'
+        with:
+          delete-branch: "true"
+          title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          branch: "api-change/${{ github.event.client_payload.BUFTAG }}"
+          base: "main"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -1,0 +1,46 @@
+---
+name: Update for API change
+on:
+  workflow_dispatch:
+    inputs:
+      buftag:
+        description: Tag or commit from https://buf.build/authzed/api/tags/main
+        required: true
+        type: string
+jobs:
+  test:
+    name: "Create PR for API update"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - name: "Update Buf Script"
+        id: buf-update
+        uses: authzed/actions/buf-api-update@main
+        with:
+          api-commit: ${{ inputs.buftag }}
+          spec-path: buf.gen.yaml
+          file-format: "buf-gen-yaml"
+      - name: "Output update status"
+        env:
+          UPDATED_STATUS: ${{ steps.buf-update.outputs.updated }}
+        run: |
+          echo "Update status: $UPDATED_STATUS"
+      - name: "Install buf"
+        uses: "bufbuild/buf-setup-action@v1.43.0"
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.buf-update.outputs.updated == 'true'
+      - name: "Run buf generate"
+        if: steps.buf-update.outputs.updated == 'true'
+        run: "buf generate"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7.0.5
+        if: steps.buf-update.outputs.updated == 'true'
+        with:
+          delete-branch: "true"
+          title: Update API to ${{ inputs.buftag }}
+          branch: api-change/${{ inputs.buftag }}
+          base: "main"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,18 +2,14 @@
 # yamllint disable rule:line-length
 version: "v2"
 plugins:
-  - protoc_builtin: "csharp"
+  - remote: "buf.build/protocolbuffers/csharp:v28.3"
     out: "src/Authzed.Net"
     opt: "base_namespace="
     include_imports: true
-    # TODO: this is arch-specific and may be host-specific as well (in terms of where .nuget is)
-    # NOTE: part of the reason this is a pain is that the csharp ecosystem expects you to use
-    # the dotnet toolchain from top-to-bottom to compile protoc, so feeding things through buf
-    # and using a local plugin isn't in their use case.
-  - local: "/home/tstirrat/.nuget/packages/grpc.tools/2.65.0/tools/linux_x64/grpc_csharp_plugin"
+  - remote: "buf.build/grpc/csharp:v1.67.1"
     out: "src/Authzed.Net"
     opt:
       - "base_namespace="
       - "no_server=on"
 inputs:
-  - module: buf.build/authzed/api:v1.37.0
+  - module: buf.build/authzed/api:v1.38.0

--- a/src/Authzed.Net/Authzed/Api/Materialize/V0/Watchpermissions.cs
+++ b/src/Authzed.Net/Authzed/Api/Materialize/V0/Watchpermissions.cs
@@ -69,6 +69,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
   #region Messages
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchPermissionsRequest : pb::IMessage<WatchPermissionsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -253,7 +254,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -279,7 +284,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -301,6 +310,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchedPermission : pb::IMessage<WatchedPermission>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -555,7 +565,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -586,7 +600,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -613,6 +631,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchPermissionsResponse : pb::IMessage<WatchPermissionsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -850,7 +869,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -883,7 +906,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -912,6 +939,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PermissionChange : pb::IMessage<PermissionChange>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1207,7 +1235,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1251,7 +1283,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/Materialize/V0/Watchpermissionsets.cs
+++ b/src/Authzed.Net/Authzed/Api/Materialize/V0/Watchpermissionsets.cs
@@ -103,6 +103,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
   #region Messages
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchPermissionSetsRequest : pb::IMessage<WatchPermissionSetsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -265,7 +266,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -287,7 +292,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -305,6 +314,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchPermissionSetsResponse : pb::IMessage<WatchPermissionSetsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -622,7 +632,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -673,7 +687,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -720,6 +738,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Cursor : pb::IMessage<Cursor>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1009,7 +1028,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1047,7 +1070,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1081,6 +1108,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupPermissionSetsRequest : pb::IMessage<LookupPermissionSetsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1313,7 +1341,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1346,7 +1378,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1375,6 +1411,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupPermissionSetsResponse : pb::IMessage<LookupPermissionSetsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1577,7 +1614,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1606,7 +1647,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1631,6 +1676,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PermissionSetChange : pb::IMessage<PermissionSetChange>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1962,7 +2008,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2013,7 +2063,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2074,6 +2128,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SetReference : pb::IMessage<SetReference>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2296,7 +2351,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2323,7 +2382,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2346,6 +2409,7 @@ namespace Authzed.Api.Materialize.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class MemberReference : pb::IMessage<MemberReference>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2568,7 +2632,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2595,7 +2663,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2623,6 +2695,7 @@ namespace Authzed.Api.Materialize.V0 {
   /// the permission set snapshot needs to be rebuilt from scratch. This typically happens when the origin SpiceDB
   /// cluster has seen its schema changed, see BreakingSchemaChange event.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupPermissionSetsRequired : pb::IMessage<LookupPermissionSetsRequired>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2784,7 +2857,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2806,7 +2883,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2829,6 +2910,7 @@ namespace Authzed.Api.Materialize.V0 {
   /// expect delays in the ingestion of new changes, because the permission set snapshot needs to be rebuilt from scratch.
   /// Once the snapshot is ready, the consumer will receive a LookupPermissionSetsRequired event.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BreakingSchemaChange : pb::IMessage<BreakingSchemaChange>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2990,7 +3072,11 @@ namespace Authzed.Api.Materialize.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3012,7 +3098,11 @@ namespace Authzed.Api.Materialize.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V0/Core.cs
+++ b/src/Authzed.Net/Authzed/Api/V0/Core.cs
@@ -58,6 +58,7 @@ namespace Authzed.Api.V0 {
 
   }
   #region Messages
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RelationTuple : pb::IMessage<RelationTuple>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -261,7 +262,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -290,7 +295,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -315,6 +324,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ObjectAndRelation : pb::IMessage<ObjectAndRelation>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -528,7 +538,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -555,7 +569,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -578,6 +596,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RelationReference : pb::IMessage<RelationReference>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -762,7 +781,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -785,7 +808,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -804,6 +831,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class User : pb::IMessage<User>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -992,7 +1020,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1016,7 +1048,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V0/Developer.cs
+++ b/src/Authzed.Net/Authzed/Api/V0/Developer.cs
@@ -123,6 +123,7 @@ namespace Authzed.Api.V0 {
 
   }
   #region Messages
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class FormatSchemaRequest : pb::IMessage<FormatSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -278,7 +279,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -297,7 +302,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -312,6 +321,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class FormatSchemaResponse : pb::IMessage<FormatSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -499,7 +509,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -525,7 +539,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -547,6 +565,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UpgradeSchemaRequest : pb::IMessage<UpgradeSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -691,7 +710,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -710,7 +733,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -725,6 +752,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UpgradeSchemaResponse : pb::IMessage<UpgradeSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -912,7 +940,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -938,7 +970,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -960,6 +996,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ShareRequest : pb::IMessage<ShareRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1202,7 +1239,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1233,7 +1274,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1260,6 +1305,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ShareResponse : pb::IMessage<ShareResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1415,7 +1461,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1434,7 +1484,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1449,6 +1503,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupShareRequest : pb::IMessage<LookupShareRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1604,7 +1659,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1623,7 +1682,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1638,6 +1701,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupShareResponse : pb::IMessage<LookupShareResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1909,7 +1973,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1944,7 +2012,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1990,6 +2062,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RequestContext : pb::IMessage<RequestContext>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2163,7 +2236,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2186,7 +2263,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2205,6 +2286,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class EditCheckRequest : pb::IMessage<EditCheckRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2381,7 +2463,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2407,7 +2493,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2429,6 +2519,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class EditCheckResult : pb::IMessage<EditCheckResult>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2648,7 +2739,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2681,7 +2776,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2710,6 +2809,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class EditCheckResponse : pb::IMessage<EditCheckResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2872,7 +2972,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2895,7 +2999,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2914,6 +3022,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ValidateRequest : pb::IMessage<ValidateRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3159,7 +3268,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3193,7 +3306,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3223,6 +3340,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ValidateResponse : pb::IMessage<ValidateResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3414,7 +3532,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3441,7 +3563,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3464,6 +3590,7 @@ namespace Authzed.Api.V0 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DeveloperError : pb::IMessage<DeveloperError>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3786,7 +3913,11 @@ namespace Authzed.Api.V0 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3829,7 +3960,11 @@ namespace Authzed.Api.V0 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V1/Core.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/Core.cs
@@ -99,6 +99,7 @@ namespace Authzed.Api.V1 {
   /// form the data for the graph over which all permissions questions are
   /// answered.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Relationship : pb::IMessage<Relationship>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -362,7 +363,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -402,7 +407,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -443,6 +452,7 @@ namespace Authzed.Api.V1 {
   /// The context consists of key-value pairs that will be injected at evaluation time.
   /// The keys must match the arguments defined on the caveat in the schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ContextualizedCaveat : pb::IMessage<ContextualizedCaveat>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -636,7 +646,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -662,7 +676,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -689,6 +707,7 @@ namespace Authzed.Api.V1 {
   /// Relationship. The relation component is optional and is used for defining a
   /// sub-relation on the subject, e.g. group:123#members
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SubjectReference : pb::IMessage<SubjectReference>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -876,7 +895,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -902,7 +925,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -927,6 +954,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ObjectReference is used to refer to a specific object in the system.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ObjectReference : pb::IMessage<ObjectReference>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1111,7 +1139,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1134,7 +1166,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1159,6 +1195,7 @@ namespace Authzed.Api.V1 {
   ///
   /// See the authzed.api.v1.Consistency message for more information.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ZedToken : pb::IMessage<ZedToken>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1314,7 +1351,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1333,7 +1374,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1352,6 +1397,7 @@ namespace Authzed.Api.V1 {
   /// Cursor is used to provide resumption of listing between calls to APIs
   /// such as LookupResources.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Cursor : pb::IMessage<Cursor>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1507,7 +1553,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1526,7 +1576,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1554,6 +1608,7 @@ namespace Authzed.Api.V1 {
   /// DELETE will delete the relationship. If the relationship does not exist,
   /// this operation will no-op.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RelationshipUpdate : pb::IMessage<RelationshipUpdate>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1741,7 +1796,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1767,7 +1826,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1808,6 +1871,7 @@ namespace Authzed.Api.V1 {
   /// PermissionRelationshipTree is used for representing a tree of a resource and
   /// its permission relationships with other objects.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PermissionRelationshipTree : pb::IMessage<PermissionRelationshipTree>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2092,7 +2156,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2136,7 +2204,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2188,6 +2260,7 @@ namespace Authzed.Api.V1 {
   /// EXCLUSION is a logical set containing only the subject members which are
   /// present in the first operand, and none of the other operands.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class AlgebraicSubjectSet : pb::IMessage<AlgebraicSubjectSet>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2361,7 +2434,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2384,7 +2461,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2421,6 +2502,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// DirectSubjectSet is a subject set which is simply a collection of subjects.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DirectSubjectSet : pb::IMessage<DirectSubjectSet>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2565,7 +2647,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2584,7 +2670,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2603,6 +2693,7 @@ namespace Authzed.Api.V1 {
   /// PartialCaveatInfo carries information necessary for the client to take action
   /// in the event a response contains a partially evaluated caveat
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PartialCaveatInfo : pb::IMessage<PartialCaveatInfo>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2751,7 +2842,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2770,7 +2865,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V1/Debug.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/Debug.cs
@@ -84,6 +84,7 @@ namespace Authzed.Api.V1 {
   ///
   /// See the github.com/authzed/authzed-go project for the specific header and footer names.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DebugInformation : pb::IMessage<DebugInformation>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -277,7 +278,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -303,7 +308,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -329,6 +338,7 @@ namespace Authzed.Api.V1 {
   /// CheckDebugTrace is a recursive trace of the requests made for resolving a CheckPermission
   /// API call.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckDebugTrace : pb::IMessage<CheckDebugTrace>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -502,10 +512,24 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public bool WasCachedResult {
-      get { return resolutionCase_ == ResolutionOneofCase.WasCachedResult ? (bool) resolution_ : false; }
+      get { return HasWasCachedResult ? (bool) resolution_ : false; }
       set {
         resolution_ = value;
         resolutionCase_ = ResolutionOneofCase.WasCachedResult;
+      }
+    }
+    /// <summary>Gets whether the "was_cached_result" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasWasCachedResult {
+      get { return resolutionCase_ == ResolutionOneofCase.WasCachedResult; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "was_cached_result" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearWasCachedResult() {
+      if (HasWasCachedResult) {
+        ClearResolution();
       }
     }
 
@@ -585,7 +609,7 @@ namespace Authzed.Api.V1 {
       if (Result != global::Authzed.Api.V1.CheckDebugTrace.Types.Permissionship.Unspecified) hash ^= Result.GetHashCode();
       if (caveatEvaluationInfo_ != null) hash ^= CaveatEvaluationInfo.GetHashCode();
       if (duration_ != null) hash ^= Duration.GetHashCode();
-      if (resolutionCase_ == ResolutionOneofCase.WasCachedResult) hash ^= WasCachedResult.GetHashCode();
+      if (HasWasCachedResult) hash ^= WasCachedResult.GetHashCode();
       if (resolutionCase_ == ResolutionOneofCase.SubProblems) hash ^= SubProblems.GetHashCode();
       hash ^= (int) resolutionCase_;
       if (_unknownFields != null) {
@@ -626,7 +650,7 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(40);
         output.WriteEnum((int) Result);
       }
-      if (resolutionCase_ == ResolutionOneofCase.WasCachedResult) {
+      if (HasWasCachedResult) {
         output.WriteRawTag(48);
         output.WriteBool(WasCachedResult);
       }
@@ -672,7 +696,7 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(40);
         output.WriteEnum((int) Result);
       }
-      if (resolutionCase_ == ResolutionOneofCase.WasCachedResult) {
+      if (HasWasCachedResult) {
         output.WriteRawTag(48);
         output.WriteBool(WasCachedResult);
       }
@@ -719,7 +743,7 @@ namespace Authzed.Api.V1 {
       if (duration_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Duration);
       }
-      if (resolutionCase_ == ResolutionOneofCase.WasCachedResult) {
+      if (HasWasCachedResult) {
         size += 1 + 1;
       }
       if (resolutionCase_ == ResolutionOneofCase.SubProblems) {
@@ -793,7 +817,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -861,7 +889,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -941,6 +973,7 @@ namespace Authzed.Api.V1 {
         [pbr::OriginalName("PERMISSIONSHIP_CONDITIONAL_PERMISSION")] ConditionalPermission = 3,
       }
 
+      [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
       public sealed partial class SubProblems : pb::IMessage<SubProblems>
       #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
           , pb::IBufferMessage
@@ -1085,7 +1118,11 @@ namespace Authzed.Api.V1 {
         #else
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
@@ -1104,7 +1141,11 @@ namespace Authzed.Api.V1 {
         void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
                 break;
@@ -1127,6 +1168,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// CaveatEvalInfo holds information about a caveat expression that was evaluated.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CaveatEvalInfo : pb::IMessage<CaveatEvalInfo>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1419,7 +1461,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1460,7 +1506,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V1/ErrorReason.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/ErrorReason.cs
@@ -25,7 +25,7 @@ namespace Authzed.Api.V1 {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "CiFhdXRoemVkL2FwaS92MS9lcnJvcl9yZWFzb24ucHJvdG8SDmF1dGh6ZWQu",
-            "YXBpLnYxKvEJCgtFcnJvclJlYXNvbhIcChhFUlJPUl9SRUFTT05fVU5TUEVD",
+            "YXBpLnYxKqIKCgtFcnJvclJlYXNvbhIcChhFUlJPUl9SRUFTT05fVU5TUEVD",
             "SUZJRUQQABIjCh9FUlJPUl9SRUFTT05fU0NIRU1BX1BBUlNFX0VSUk9SEAES",
             "IgoeRVJST1JfUkVBU09OX1NDSEVNQV9UWVBFX0VSUk9SEAISIwofRVJST1Jf",
             "UkVBU09OX1VOS05PV05fREVGSU5JVElPThADEi8KK0VSUk9SX1JFQVNPTl9V",
@@ -53,9 +53,10 @@ namespace Authzed.Api.V1 {
             "U09OX0VNUFRZX1BSRUNPTkRJVElPThAZEisKJ0VSUk9SX1JFQVNPTl9DT1VO",
             "VEVSX0FMUkVBRFlfUkVHSVNURVJFRBAaEicKI0VSUk9SX1JFQVNPTl9DT1VO",
             "VEVSX05PVF9SRUdJU1RFUkVEEBsSJQohRVJST1JfUkVBU09OX1dJTERDQVJE",
-            "X05PVF9BTExPV0VEEBxCSgoSY29tLmF1dGh6ZWQuYXBpLnYxUAFaMmdpdGh1",
-            "Yi5jb20vYXV0aHplZC9hdXRoemVkLWdvL3Byb3RvL2F1dGh6ZWQvYXBpL3Yx",
-            "YgZwcm90bzM="));
+            "X05PVF9BTExPV0VEEBwSLworRVJST1JfUkVBU09OX1RSQU5TQUNUSU9OX01F",
+            "VEFEQVRBX1RPT19MQVJHRRAdQkoKEmNvbS5hdXRoemVkLmFwaS52MVABWjJn",
+            "aXRodWIuY29tL2F1dGh6ZWQvYXV0aHplZC1nby9wcm90by9hdXRoemVkL2Fw",
+            "aS92MWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Authzed.Api.V1.ErrorReason), }, null, null));
@@ -490,6 +491,21 @@ namespace Authzed.Api.V1 {
     ///     }
     /// </summary>
     [pbr::OriginalName("ERROR_REASON_WILDCARD_NOT_ALLOWED")] WildcardNotAllowed = 28,
+    /// <summary>
+    /// The request failed because the transaction metadata was too large.
+    ///
+    /// Example of an ErrorInfo:
+    ///
+    ///     {
+    ///       "reason": "ERROR_REASON_TRANSACTION_METADATA_TOO_LARGE",
+    ///       "domain": "authzed.com",
+    ///       "metadata": {
+    ///         "metadata_byte_size": "1024",
+    ///         "maximum_allowed_metadata_byte_size": "512",
+    ///       }
+    ///     }
+    /// </summary>
+    [pbr::OriginalName("ERROR_REASON_TRANSACTION_METADATA_TOO_LARGE")] TransactionMetadataTooLarge = 29,
   }
 
   #endregion

--- a/src/Authzed.Net/Authzed/Api/V1/ExperimentalService.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/ExperimentalService.cs
@@ -201,48 +201,48 @@ namespace Authzed.Api.V1 {
             "ZUNoYW5nZWRCBgoEZGlmZjKqDwoTRXhwZXJpbWVudGFsU2VydmljZRKyAQoX",
             "QnVsa0ltcG9ydFJlbGF0aW9uc2hpcHMSLi5hdXRoemVkLmFwaS52MS5CdWxr",
             "SW1wb3J0UmVsYXRpb25zaGlwc1JlcXVlc3QaLy5hdXRoemVkLmFwaS52MS5C",
-            "dWxrSW1wb3J0UmVsYXRpb25zaGlwc1Jlc3BvbnNlIjSC0+STAi46ASoiKS92",
-            "MS9leHBlcmltZW50YWwvcmVsYXRpb25zaGlwcy9idWxraW1wb3J0KAESsgEK",
+            "dWxrSW1wb3J0UmVsYXRpb25zaGlwc1Jlc3BvbnNlIjSC0+STAi4iKS92MS9l",
+            "eHBlcmltZW50YWwvcmVsYXRpb25zaGlwcy9idWxraW1wb3J0OgEqKAESsgEK",
             "F0J1bGtFeHBvcnRSZWxhdGlvbnNoaXBzEi4uYXV0aHplZC5hcGkudjEuQnVs",
             "a0V4cG9ydFJlbGF0aW9uc2hpcHNSZXF1ZXN0Gi8uYXV0aHplZC5hcGkudjEu",
-            "QnVsa0V4cG9ydFJlbGF0aW9uc2hpcHNSZXNwb25zZSI0gtPkkwIuOgEqIikv",
-            "djEvZXhwZXJpbWVudGFsL3JlbGF0aW9uc2hpcHMvYnVsa2V4cG9ydDABEq4B",
+            "QnVsa0V4cG9ydFJlbGF0aW9uc2hpcHNSZXNwb25zZSI0gtPkkwIuIikvdjEv",
+            "ZXhwZXJpbWVudGFsL3JlbGF0aW9uc2hpcHMvYnVsa2V4cG9ydDoBKjABEq4B",
             "ChNCdWxrQ2hlY2tQZXJtaXNzaW9uEiouYXV0aHplZC5hcGkudjEuQnVsa0No",
             "ZWNrUGVybWlzc2lvblJlcXVlc3QaKy5hdXRoemVkLmFwaS52MS5CdWxrQ2hl",
-            "Y2tQZXJtaXNzaW9uUmVzcG9uc2UiPogCAYLT5JMCNToBKiIwL3YxL2V4cGVy",
-            "aW1lbnRhbC9wZXJtaXNzaW9ucy9idWxrY2hlY2twZXJtaXNzaW9uEqsBChlF",
+            "Y2tQZXJtaXNzaW9uUmVzcG9uc2UiPogCAYLT5JMCNSIwL3YxL2V4cGVyaW1l",
+            "bnRhbC9wZXJtaXNzaW9ucy9idWxrY2hlY2twZXJtaXNzaW9uOgEqEqsBChlF",
             "eHBlcmltZW50YWxSZWZsZWN0U2NoZW1hEjAuYXV0aHplZC5hcGkudjEuRXhw",
             "ZXJpbWVudGFsUmVmbGVjdFNjaGVtYVJlcXVlc3QaMS5hdXRoemVkLmFwaS52",
-            "MS5FeHBlcmltZW50YWxSZWZsZWN0U2NoZW1hUmVzcG9uc2UiKYLT5JMCIzoB",
-            "KiIeL3YxL2V4cGVyaW1lbnRhbC9yZWZsZWN0c2NoZW1hEswBCiFFeHBlcmlt",
+            "MS5FeHBlcmltZW50YWxSZWZsZWN0U2NoZW1hUmVzcG9uc2UiKYLT5JMCIyIe",
+            "L3YxL2V4cGVyaW1lbnRhbC9yZWZsZWN0c2NoZW1hOgEqEswBCiFFeHBlcmlt",
             "ZW50YWxDb21wdXRhYmxlUGVybWlzc2lvbnMSOC5hdXRoemVkLmFwaS52MS5F",
             "eHBlcmltZW50YWxDb21wdXRhYmxlUGVybWlzc2lvbnNSZXF1ZXN0GjkuYXV0",
             "aHplZC5hcGkudjEuRXhwZXJpbWVudGFsQ29tcHV0YWJsZVBlcm1pc3Npb25z",
-            "UmVzcG9uc2UiMoLT5JMCLDoBKiInL3YxL2V4cGVyaW1lbnRhbC9wZXJtaXNz",
-            "aW9ucy9jb21wdXRhYmxlEsIBCh5FeHBlcmltZW50YWxEZXBlbmRlbnRSZWxh",
+            "UmVzcG9uc2UiMoLT5JMCLCInL3YxL2V4cGVyaW1lbnRhbC9wZXJtaXNzaW9u",
+            "cy9jb21wdXRhYmxlOgEqEsIBCh5FeHBlcmltZW50YWxEZXBlbmRlbnRSZWxh",
             "dGlvbnMSNS5hdXRoemVkLmFwaS52MS5FeHBlcmltZW50YWxEZXBlbmRlbnRS",
             "ZWxhdGlvbnNSZXF1ZXN0GjYuYXV0aHplZC5hcGkudjEuRXhwZXJpbWVudGFs",
-            "RGVwZW5kZW50UmVsYXRpb25zUmVzcG9uc2UiMYLT5JMCKzoBKiImL3YxL2V4",
-            "cGVyaW1lbnRhbC9wZXJtaXNzaW9ucy9kZXBlbmRlbnQSnwEKFkV4cGVyaW1l",
+            "RGVwZW5kZW50UmVsYXRpb25zUmVzcG9uc2UiMYLT5JMCKyImL3YxL2V4cGVy",
+            "aW1lbnRhbC9wZXJtaXNzaW9ucy9kZXBlbmRlbnQ6ASoSnwEKFkV4cGVyaW1l",
             "bnRhbERpZmZTY2hlbWESLS5hdXRoemVkLmFwaS52MS5FeHBlcmltZW50YWxE",
             "aWZmU2NoZW1hUmVxdWVzdBouLmF1dGh6ZWQuYXBpLnYxLkV4cGVyaW1lbnRh",
-            "bERpZmZTY2hlbWFSZXNwb25zZSImgtPkkwIgOgEqIhsvdjEvZXhwZXJpbWVu",
-            "dGFsL2RpZmZzY2hlbWES4wEKJ0V4cGVyaW1lbnRhbFJlZ2lzdGVyUmVsYXRp",
+            "bERpZmZTY2hlbWFSZXNwb25zZSImgtPkkwIgIhsvdjEvZXhwZXJpbWVudGFs",
+            "L2RpZmZzY2hlbWE6ASoS4wEKJ0V4cGVyaW1lbnRhbFJlZ2lzdGVyUmVsYXRp",
             "b25zaGlwQ291bnRlchI+LmF1dGh6ZWQuYXBpLnYxLkV4cGVyaW1lbnRhbFJl",
             "Z2lzdGVyUmVsYXRpb25zaGlwQ291bnRlclJlcXVlc3QaPy5hdXRoemVkLmFw",
             "aS52MS5FeHBlcmltZW50YWxSZWdpc3RlclJlbGF0aW9uc2hpcENvdW50ZXJS",
-            "ZXNwb25zZSI3gtPkkwIxOgEqIiwvdjEvZXhwZXJpbWVudGFsL3JlZ2lzdGVy",
-            "cmVsYXRpb25zaGlwY291bnRlchK/AQoeRXhwZXJpbWVudGFsQ291bnRSZWxh",
+            "ZXNwb25zZSI3gtPkkwIxIiwvdjEvZXhwZXJpbWVudGFsL3JlZ2lzdGVycmVs",
+            "YXRpb25zaGlwY291bnRlcjoBKhK/AQoeRXhwZXJpbWVudGFsQ291bnRSZWxh",
             "dGlvbnNoaXBzEjUuYXV0aHplZC5hcGkudjEuRXhwZXJpbWVudGFsQ291bnRS",
             "ZWxhdGlvbnNoaXBzUmVxdWVzdBo2LmF1dGh6ZWQuYXBpLnYxLkV4cGVyaW1l",
-            "bnRhbENvdW50UmVsYXRpb25zaGlwc1Jlc3BvbnNlIi6C0+STAig6ASoiIy92",
-            "MS9leHBlcmltZW50YWwvY291bnRyZWxhdGlvbnNoaXBzEusBCilFeHBlcmlt",
+            "bnRhbENvdW50UmVsYXRpb25zaGlwc1Jlc3BvbnNlIi6C0+STAigiIy92MS9l",
+            "eHBlcmltZW50YWwvY291bnRyZWxhdGlvbnNoaXBzOgEqEusBCilFeHBlcmlt",
             "ZW50YWxVbnJlZ2lzdGVyUmVsYXRpb25zaGlwQ291bnRlchJALmF1dGh6ZWQu",
             "YXBpLnYxLkV4cGVyaW1lbnRhbFVucmVnaXN0ZXJSZWxhdGlvbnNoaXBDb3Vu",
             "dGVyUmVxdWVzdBpBLmF1dGh6ZWQuYXBpLnYxLkV4cGVyaW1lbnRhbFVucmVn",
-            "aXN0ZXJSZWxhdGlvbnNoaXBDb3VudGVyUmVzcG9uc2UiOYLT5JMCMzoBKiIu",
-            "L3YxL2V4cGVyaW1lbnRhbC91bnJlZ2lzdGVycmVsYXRpb25zaGlwY291bnRl",
-            "ckJKChJjb20uYXV0aHplZC5hcGkudjFQAVoyZ2l0aHViLmNvbS9hdXRoemVk",
+            "aXN0ZXJSZWxhdGlvbnNoaXBDb3VudGVyUmVzcG9uc2UiOYLT5JMCMyIuL3Yx",
+            "L2V4cGVyaW1lbnRhbC91bnJlZ2lzdGVycmVsYXRpb25zaGlwY291bnRlcjoB",
+            "KkJKChJjb20uYXV0aHplZC5hcGkudjFQAVoyZ2l0aHViLmNvbS9hdXRoemVk",
             "L2F1dGh6ZWQtZ28vcHJvdG8vYXV0aHplZC9hcGkvdjFiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Rpc.StatusReflection.Descriptor, global::Authzed.Api.V1.CoreReflection.Descriptor, global::Authzed.Api.V1.PermissionServiceReflection.Descriptor, },
@@ -288,6 +288,7 @@ namespace Authzed.Api.V1 {
 
   }
   #region Messages
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalRegisterRelationshipCounterRequest : pb::IMessage<ExperimentalRegisterRelationshipCounterRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -482,7 +483,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -508,7 +513,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -530,6 +539,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalRegisterRelationshipCounterResponse : pb::IMessage<ExperimentalRegisterRelationshipCounterResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -656,7 +666,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -671,7 +685,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -682,6 +700,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalCountRelationshipsRequest : pb::IMessage<ExperimentalCountRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -840,7 +859,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -859,7 +882,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -874,6 +901,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalCountRelationshipsResponse : pb::IMessage<ExperimentalCountRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -934,10 +962,24 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public bool CounterStillCalculating {
-      get { return counterResultCase_ == CounterResultOneofCase.CounterStillCalculating ? (bool) counterResult_ : false; }
+      get { return HasCounterStillCalculating ? (bool) counterResult_ : false; }
       set {
         counterResult_ = value;
         counterResultCase_ = CounterResultOneofCase.CounterStillCalculating;
+      }
+    }
+    /// <summary>Gets whether the "counter_still_calculating" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasCounterStillCalculating {
+      get { return counterResultCase_ == CounterResultOneofCase.CounterStillCalculating; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "counter_still_calculating" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearCounterStillCalculating() {
+      if (HasCounterStillCalculating) {
+        ClearCounterResult();
       }
     }
 
@@ -1002,7 +1044,7 @@ namespace Authzed.Api.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
-      if (counterResultCase_ == CounterResultOneofCase.CounterStillCalculating) hash ^= CounterStillCalculating.GetHashCode();
+      if (HasCounterStillCalculating) hash ^= CounterStillCalculating.GetHashCode();
       if (counterResultCase_ == CounterResultOneofCase.ReadCounterValue) hash ^= ReadCounterValue.GetHashCode();
       hash ^= (int) counterResultCase_;
       if (_unknownFields != null) {
@@ -1023,7 +1065,7 @@ namespace Authzed.Api.V1 {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (counterResultCase_ == CounterResultOneofCase.CounterStillCalculating) {
+      if (HasCounterStillCalculating) {
         output.WriteRawTag(8);
         output.WriteBool(CounterStillCalculating);
       }
@@ -1041,7 +1083,7 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (counterResultCase_ == CounterResultOneofCase.CounterStillCalculating) {
+      if (HasCounterStillCalculating) {
         output.WriteRawTag(8);
         output.WriteBool(CounterStillCalculating);
       }
@@ -1059,7 +1101,7 @@ namespace Authzed.Api.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
-      if (counterResultCase_ == CounterResultOneofCase.CounterStillCalculating) {
+      if (HasCounterStillCalculating) {
         size += 1 + 1;
       }
       if (counterResultCase_ == CounterResultOneofCase.ReadCounterValue) {
@@ -1100,7 +1142,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1128,7 +1174,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1152,6 +1202,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadCounterValue : pb::IMessage<ReadCounterValue>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1345,7 +1396,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1371,7 +1426,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1393,6 +1452,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalUnregisterRelationshipCounterRequest : pb::IMessage<ExperimentalUnregisterRelationshipCounterRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1551,7 +1611,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1570,7 +1634,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1585,6 +1653,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalUnregisterRelationshipCounterResponse : pb::IMessage<ExperimentalUnregisterRelationshipCounterResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1711,7 +1780,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1726,7 +1799,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1740,6 +1817,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// NOTE: Deprecated now that BulkCheckPermission has been promoted to the stable API as "CheckBulkPermission".
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkCheckPermissionRequest : pb::IMessage<BulkCheckPermissionRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1917,7 +1995,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1943,7 +2025,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1965,6 +2051,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkCheckPermissionRequestItem : pb::IMessage<BulkCheckPermissionRequestItem>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2216,7 +2303,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2256,7 +2347,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2292,6 +2387,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkCheckPermissionResponse : pb::IMessage<BulkCheckPermissionResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2468,7 +2564,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2494,7 +2594,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2516,6 +2620,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkCheckPermissionPair : pb::IMessage<BulkCheckPermissionPair>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2771,7 +2876,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2811,7 +2920,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2847,6 +2960,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkCheckPermissionResponseItem : pb::IMessage<BulkCheckPermissionResponseItem>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3034,7 +3148,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3060,7 +3178,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3086,8 +3208,11 @@ namespace Authzed.Api.V1 {
   /// BulkImportRelationshipsRequest represents one batch of the streaming
   /// BulkImportRelationships API. The maximum size is only limited by the backing
   /// datastore, and optimal size should be determined by the calling client
-  /// experimentally.
+  /// experimentally. Any relationships within the same request are guaranteed to
+  /// be written in a single transaction. If any of the relationships already
+  /// exist, the transaction will fail and no relationships will be written.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkImportRelationshipsRequest : pb::IMessage<BulkImportRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3232,7 +3357,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3251,7 +3380,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3270,6 +3403,7 @@ namespace Authzed.Api.V1 {
   /// BulkImportRelationshipsResponse is returned on successful completion of the
   /// bulk load stream, and contains the total number of relationships loaded.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkImportRelationshipsResponse : pb::IMessage<BulkImportRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3425,7 +3559,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3444,7 +3582,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3463,6 +3605,7 @@ namespace Authzed.Api.V1 {
   /// BulkExportRelationshipsRequest represents a resumable request for
   /// all relationships from the server.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkExportRelationshipsRequest : pb::IMessage<BulkExportRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3729,7 +3872,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3769,7 +3916,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3811,6 +3962,7 @@ namespace Authzed.Api.V1 {
   /// server will continue to stream back relationship groups as quickly as it can
   /// until all relationships have been transmitted back.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BulkExportRelationshipsResponse : pb::IMessage<BulkExportRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3987,7 +4139,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4013,7 +4169,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4035,6 +4195,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalReflectSchemaRequest : pb::IMessage<ExperimentalReflectSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4215,7 +4376,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4241,7 +4406,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4263,6 +4432,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalReflectSchemaResponse : pb::IMessage<ExperimentalReflectSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4466,7 +4636,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4496,7 +4670,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4525,6 +4703,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpSchemaFilter is a filter that can be applied to the schema on reflection.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpSchemaFilter : pb::IMessage<ExpSchemaFilter>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4779,7 +4958,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4810,7 +4993,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4840,6 +5027,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpDefinition is the representation of a definition in the schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpDefinition : pb::IMessage<ExpDefinition>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5064,7 +5252,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5095,7 +5287,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5125,6 +5321,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpCaveat is the representation of a caveat in the schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpCaveat : pb::IMessage<ExpCaveat>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5360,7 +5557,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5391,7 +5592,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5421,6 +5626,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpCaveatParameter is the representation of a parameter in a caveat.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpCaveatParameter : pb::IMessage<ExpCaveatParameter>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5638,7 +5844,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5665,7 +5875,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5691,6 +5905,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpRelation is the representation of a relation in the schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpRelation : pb::IMessage<ExpRelation>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5922,7 +6137,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5953,7 +6172,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5983,6 +6206,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpTypeReference is the representation of a type reference in the schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpTypeReference : pb::IMessage<ExpTypeReference>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6078,10 +6302,24 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public bool IsTerminalSubject {
-      get { return typerefCase_ == TyperefOneofCase.IsTerminalSubject ? (bool) typeref_ : false; }
+      get { return HasIsTerminalSubject ? (bool) typeref_ : false; }
       set {
         typeref_ = value;
         typerefCase_ = TyperefOneofCase.IsTerminalSubject;
+      }
+    }
+    /// <summary>Gets whether the "is_terminal_subject" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasIsTerminalSubject {
+      get { return typerefCase_ == TyperefOneofCase.IsTerminalSubject; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "is_terminal_subject" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearIsTerminalSubject() {
+      if (HasIsTerminalSubject) {
+        ClearTyperef();
       }
     }
 
@@ -6093,10 +6331,24 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string OptionalRelationName {
-      get { return typerefCase_ == TyperefOneofCase.OptionalRelationName ? (string) typeref_ : ""; }
+      get { return HasOptionalRelationName ? (string) typeref_ : ""; }
       set {
         typeref_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         typerefCase_ = TyperefOneofCase.OptionalRelationName;
+      }
+    }
+    /// <summary>Gets whether the "optional_relation_name" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasOptionalRelationName {
+      get { return typerefCase_ == TyperefOneofCase.OptionalRelationName; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "optional_relation_name" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearOptionalRelationName() {
+      if (HasOptionalRelationName) {
+        ClearTyperef();
       }
     }
 
@@ -6108,10 +6360,24 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public bool IsPublicWildcard {
-      get { return typerefCase_ == TyperefOneofCase.IsPublicWildcard ? (bool) typeref_ : false; }
+      get { return HasIsPublicWildcard ? (bool) typeref_ : false; }
       set {
         typeref_ = value;
         typerefCase_ = TyperefOneofCase.IsPublicWildcard;
+      }
+    }
+    /// <summary>Gets whether the "is_public_wildcard" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasIsPublicWildcard {
+      get { return typerefCase_ == TyperefOneofCase.IsPublicWildcard; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "is_public_wildcard" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearIsPublicWildcard() {
+      if (HasIsPublicWildcard) {
+        ClearTyperef();
       }
     }
 
@@ -6167,9 +6433,9 @@ namespace Authzed.Api.V1 {
       int hash = 1;
       if (SubjectDefinitionName.Length != 0) hash ^= SubjectDefinitionName.GetHashCode();
       if (OptionalCaveatName.Length != 0) hash ^= OptionalCaveatName.GetHashCode();
-      if (typerefCase_ == TyperefOneofCase.IsTerminalSubject) hash ^= IsTerminalSubject.GetHashCode();
-      if (typerefCase_ == TyperefOneofCase.OptionalRelationName) hash ^= OptionalRelationName.GetHashCode();
-      if (typerefCase_ == TyperefOneofCase.IsPublicWildcard) hash ^= IsPublicWildcard.GetHashCode();
+      if (HasIsTerminalSubject) hash ^= IsTerminalSubject.GetHashCode();
+      if (HasOptionalRelationName) hash ^= OptionalRelationName.GetHashCode();
+      if (HasIsPublicWildcard) hash ^= IsPublicWildcard.GetHashCode();
       hash ^= (int) typerefCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -6197,15 +6463,15 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(18);
         output.WriteString(OptionalCaveatName);
       }
-      if (typerefCase_ == TyperefOneofCase.IsTerminalSubject) {
+      if (HasIsTerminalSubject) {
         output.WriteRawTag(24);
         output.WriteBool(IsTerminalSubject);
       }
-      if (typerefCase_ == TyperefOneofCase.OptionalRelationName) {
+      if (HasOptionalRelationName) {
         output.WriteRawTag(34);
         output.WriteString(OptionalRelationName);
       }
-      if (typerefCase_ == TyperefOneofCase.IsPublicWildcard) {
+      if (HasIsPublicWildcard) {
         output.WriteRawTag(40);
         output.WriteBool(IsPublicWildcard);
       }
@@ -6227,15 +6493,15 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(18);
         output.WriteString(OptionalCaveatName);
       }
-      if (typerefCase_ == TyperefOneofCase.IsTerminalSubject) {
+      if (HasIsTerminalSubject) {
         output.WriteRawTag(24);
         output.WriteBool(IsTerminalSubject);
       }
-      if (typerefCase_ == TyperefOneofCase.OptionalRelationName) {
+      if (HasOptionalRelationName) {
         output.WriteRawTag(34);
         output.WriteString(OptionalRelationName);
       }
-      if (typerefCase_ == TyperefOneofCase.IsPublicWildcard) {
+      if (HasIsPublicWildcard) {
         output.WriteRawTag(40);
         output.WriteBool(IsPublicWildcard);
       }
@@ -6255,13 +6521,13 @@ namespace Authzed.Api.V1 {
       if (OptionalCaveatName.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(OptionalCaveatName);
       }
-      if (typerefCase_ == TyperefOneofCase.IsTerminalSubject) {
+      if (HasIsTerminalSubject) {
         size += 1 + 1;
       }
-      if (typerefCase_ == TyperefOneofCase.OptionalRelationName) {
+      if (HasOptionalRelationName) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(OptionalRelationName);
       }
-      if (typerefCase_ == TyperefOneofCase.IsPublicWildcard) {
+      if (HasIsPublicWildcard) {
         size += 1 + 1;
       }
       if (_unknownFields != null) {
@@ -6305,7 +6571,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6340,7 +6610,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6374,6 +6648,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpPermission is the representation of a permission in the schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpPermission : pb::IMessage<ExpPermission>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6591,7 +6866,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6618,7 +6897,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6641,6 +6924,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalComputablePermissionsRequest : pb::IMessage<ExperimentalComputablePermissionsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6891,7 +7175,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6925,7 +7213,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6958,6 +7250,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpRelationReference is a reference to a relation or permission in the schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpRelationReference : pb::IMessage<ExpRelationReference>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7171,7 +7464,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -7198,7 +7495,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7221,6 +7522,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalComputablePermissionsResponse : pb::IMessage<ExperimentalComputablePermissionsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7400,7 +7702,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -7426,7 +7732,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7448,6 +7758,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalDependentRelationsRequest : pb::IMessage<ExperimentalDependentRelationsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7664,7 +7975,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -7694,7 +8009,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7720,6 +8039,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalDependentRelationsResponse : pb::IMessage<ExperimentalDependentRelationsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7899,7 +8219,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -7925,7 +8249,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7947,6 +8275,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalDiffSchemaRequest : pb::IMessage<ExperimentalDiffSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8134,7 +8463,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8160,7 +8493,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8182,6 +8519,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExperimentalDiffSchemaResponse : pb::IMessage<ExperimentalDiffSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8361,7 +8699,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8387,7 +8729,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8409,6 +8755,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpRelationSubjectTypeChange : pb::IMessage<ExpRelationSubjectTypeChange>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8599,7 +8946,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8628,7 +8979,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8653,6 +9008,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpCaveatParameterTypeChange : pb::IMessage<ExpCaveatParameterTypeChange>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8840,7 +9196,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8866,7 +9226,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8891,6 +9255,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ExpSchemaDiff is the representation of a diff between two schemas.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpSchemaDiff : pb::IMessage<ExpSchemaDiff>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -9709,7 +10074,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -9895,7 +10264,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V1/PermissionService.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/PermissionService.cs
@@ -73,196 +73,201 @@ namespace Authzed.Api.V1 {
             "YXV0aHplZC5hcGkudjEuUmVsYXRpb25zaGlwRmlsdGVyQgj6QgWKAQIQAVIG",
             "ZmlsdGVyIl4KCU9wZXJhdGlvbhIZChVPUEVSQVRJT05fVU5TUEVDSUZJRUQQ",
             "ABIcChhPUEVSQVRJT05fTVVTVF9OT1RfTUFUQ0gQARIYChRPUEVSQVRJT05f",
-            "TVVTVF9NQVRDSBACIswBChlXcml0ZVJlbGF0aW9uc2hpcHNSZXF1ZXN0EksK",
+            "TVVTVF9NQVRDSBACIrMCChlXcml0ZVJlbGF0aW9uc2hpcHNSZXF1ZXN0EksK",
             "B3VwZGF0ZXMYASADKAsyIi5hdXRoemVkLmFwaS52MS5SZWxhdGlvbnNoaXBV",
             "cGRhdGVCDfpCCpIBByIFigECEAFSB3VwZGF0ZXMSYgoWb3B0aW9uYWxfcHJl",
             "Y29uZGl0aW9ucxgCIAMoCzIcLmF1dGh6ZWQuYXBpLnYxLlByZWNvbmRpdGlv",
-            "bkIN+kIKkgEHIgWKAQIQAVIVb3B0aW9uYWxQcmVjb25kaXRpb25zIlUKGldy",
-            "aXRlUmVsYXRpb25zaGlwc1Jlc3BvbnNlEjcKCndyaXR0ZW5fYXQYASABKAsy",
-            "GC5hdXRoemVkLmFwaS52MS5aZWRUb2tlblIJd3JpdHRlbkF0ItgCChpEZWxl",
-            "dGVSZWxhdGlvbnNoaXBzUmVxdWVzdBJdChNyZWxhdGlvbnNoaXBfZmlsdGVy",
-            "GAEgASgLMiIuYXV0aHplZC5hcGkudjEuUmVsYXRpb25zaGlwRmlsdGVyQgj6",
-            "QgWKAQIQAVIScmVsYXRpb25zaGlwRmlsdGVyEmIKFm9wdGlvbmFsX3ByZWNv",
-            "bmRpdGlvbnMYAiADKAsyHC5hdXRoemVkLmFwaS52MS5QcmVjb25kaXRpb25C",
-            "DfpCCpIBByIFigECEAFSFW9wdGlvbmFsUHJlY29uZGl0aW9ucxIuCg5vcHRp",
-            "b25hbF9saW1pdBgDIAEoDUIH+kIEKgIoAFINb3B0aW9uYWxMaW1pdBJHCiBv",
-            "cHRpb25hbF9hbGxvd19wYXJ0aWFsX2RlbGV0aW9ucxgEIAEoCFIdb3B0aW9u",
-            "YWxBbGxvd1BhcnRpYWxEZWxldGlvbnMitwIKG0RlbGV0ZVJlbGF0aW9uc2hp",
-            "cHNSZXNwb25zZRI3CgpkZWxldGVkX2F0GAEgASgLMhguYXV0aHplZC5hcGku",
-            "djEuWmVkVG9rZW5SCWRlbGV0ZWRBdBJpChFkZWxldGlvbl9wcm9ncmVzcxgC",
-            "IAEoDjI8LmF1dGh6ZWQuYXBpLnYxLkRlbGV0ZVJlbGF0aW9uc2hpcHNSZXNw",
-            "b25zZS5EZWxldGlvblByb2dyZXNzUhBkZWxldGlvblByb2dyZXNzInQKEERl",
-            "bGV0aW9uUHJvZ3Jlc3MSIQodREVMRVRJT05fUFJPR1JFU1NfVU5TUEVDSUZJ",
-            "RUQQABIeChpERUxFVElPTl9QUk9HUkVTU19DT01QTEVURRABEh0KGURFTEVU",
-            "SU9OX1BST0dSRVNTX1BBUlRJQUwQAiKQAwoWQ2hlY2tQZXJtaXNzaW9uUmVx",
-            "dWVzdBI9Cgtjb25zaXN0ZW5jeRgBIAEoCzIbLmF1dGh6ZWQuYXBpLnYxLkNv",
-            "bnNpc3RlbmN5Ugtjb25zaXN0ZW5jeRJFCghyZXNvdXJjZRgCIAEoCzIfLmF1",
-            "dGh6ZWQuYXBpLnYxLk9iamVjdFJlZmVyZW5jZUII+kIFigECEAFSCHJlc291",
-            "cmNlEkoKCnBlcm1pc3Npb24YAyABKAlCKvpCJ3IlKEAyIV4oW2Etel1bYS16",
-            "MC05X117MSw2Mn1bYS16MC05XSk/JFIKcGVybWlzc2lvbhJECgdzdWJqZWN0",
-            "GAQgASgLMiAuYXV0aHplZC5hcGkudjEuU3ViamVjdFJlZmVyZW5jZUII+kIF",
-            "igECEAFSB3N1YmplY3QSOwoHY29udGV4dBgFIAEoCzIXLmdvb2dsZS5wcm90",
-            "b2J1Zi5TdHJ1Y3RCCPpCBYoBAhAAUgdjb250ZXh0EiEKDHdpdGhfdHJhY2lu",
-            "ZxgGIAEoCFILd2l0aFRyYWNpbmciiwQKF0NoZWNrUGVybWlzc2lvblJlc3Bv",
-            "bnNlEkEKCmNoZWNrZWRfYXQYASABKAsyGC5hdXRoemVkLmFwaS52MS5aZWRU",
-            "b2tlbkII+kIFigECEABSCWNoZWNrZWRBdBJqCg5wZXJtaXNzaW9uc2hpcBgC",
-            "IAEoDjI2LmF1dGh6ZWQuYXBpLnYxLkNoZWNrUGVybWlzc2lvblJlc3BvbnNl",
-            "LlBlcm1pc3Npb25zaGlwQgr6QgeCAQQQASAAUg5wZXJtaXNzaW9uc2hpcBJb",
-            "ChNwYXJ0aWFsX2NhdmVhdF9pbmZvGAMgASgLMiEuYXV0aHplZC5hcGkudjEu",
-            "UGFydGlhbENhdmVhdEluZm9CCPpCBYoBAhAAUhFwYXJ0aWFsQ2F2ZWF0SW5m",
-            "bxJBCgtkZWJ1Z190cmFjZRgEIAEoCzIgLmF1dGh6ZWQuYXBpLnYxLkRlYnVn",
-            "SW5mb3JtYXRpb25SCmRlYnVnVHJhY2UioAEKDlBlcm1pc3Npb25zaGlwEh4K",
-            "GlBFUk1JU1NJT05TSElQX1VOU1BFQ0lGSUVEEAASIAocUEVSTUlTU0lPTlNI",
-            "SVBfTk9fUEVSTUlTU0lPThABEiEKHVBFUk1JU1NJT05TSElQX0hBU19QRVJN",
-            "SVNTSU9OEAISKQolUEVSTUlTU0lPTlNISVBfQ09ORElUSU9OQUxfUEVSTUlT",
-            "U0lPThADIrIBChtDaGVja0J1bGtQZXJtaXNzaW9uc1JlcXVlc3QSPQoLY29u",
+            "bkIN+kIKkgEHIgWKAQIQAVIVb3B0aW9uYWxQcmVjb25kaXRpb25zEmUKHW9w",
+            "dGlvbmFsX3RyYW5zYWN0aW9uX21ldGFkYXRhGAMgASgLMhcuZ29vZ2xlLnBy",
+            "b3RvYnVmLlN0cnVjdEII+kIFigECEABSG29wdGlvbmFsVHJhbnNhY3Rpb25N",
+            "ZXRhZGF0YSJVChpXcml0ZVJlbGF0aW9uc2hpcHNSZXNwb25zZRI3Cgp3cml0",
+            "dGVuX2F0GAEgASgLMhguYXV0aHplZC5hcGkudjEuWmVkVG9rZW5SCXdyaXR0",
+            "ZW5BdCK/AwoaRGVsZXRlUmVsYXRpb25zaGlwc1JlcXVlc3QSXQoTcmVsYXRp",
+            "b25zaGlwX2ZpbHRlchgBIAEoCzIiLmF1dGh6ZWQuYXBpLnYxLlJlbGF0aW9u",
+            "c2hpcEZpbHRlckII+kIFigECEAFSEnJlbGF0aW9uc2hpcEZpbHRlchJiChZv",
+            "cHRpb25hbF9wcmVjb25kaXRpb25zGAIgAygLMhwuYXV0aHplZC5hcGkudjEu",
+            "UHJlY29uZGl0aW9uQg36QgqSAQciBYoBAhABUhVvcHRpb25hbFByZWNvbmRp",
+            "dGlvbnMSLgoOb3B0aW9uYWxfbGltaXQYAyABKA1CB/pCBCoCKABSDW9wdGlv",
+            "bmFsTGltaXQSRwogb3B0aW9uYWxfYWxsb3dfcGFydGlhbF9kZWxldGlvbnMY",
+            "BCABKAhSHW9wdGlvbmFsQWxsb3dQYXJ0aWFsRGVsZXRpb25zEmUKHW9wdGlv",
+            "bmFsX3RyYW5zYWN0aW9uX21ldGFkYXRhGAUgASgLMhcuZ29vZ2xlLnByb3Rv",
+            "YnVmLlN0cnVjdEII+kIFigECEABSG29wdGlvbmFsVHJhbnNhY3Rpb25NZXRh",
+            "ZGF0YSK3AgobRGVsZXRlUmVsYXRpb25zaGlwc1Jlc3BvbnNlEjcKCmRlbGV0",
+            "ZWRfYXQYASABKAsyGC5hdXRoemVkLmFwaS52MS5aZWRUb2tlblIJZGVsZXRl",
+            "ZEF0EmkKEWRlbGV0aW9uX3Byb2dyZXNzGAIgASgOMjwuYXV0aHplZC5hcGku",
+            "djEuRGVsZXRlUmVsYXRpb25zaGlwc1Jlc3BvbnNlLkRlbGV0aW9uUHJvZ3Jl",
+            "c3NSEGRlbGV0aW9uUHJvZ3Jlc3MidAoQRGVsZXRpb25Qcm9ncmVzcxIhCh1E",
+            "RUxFVElPTl9QUk9HUkVTU19VTlNQRUNJRklFRBAAEh4KGkRFTEVUSU9OX1BS",
+            "T0dSRVNTX0NPTVBMRVRFEAESHQoZREVMRVRJT05fUFJPR1JFU1NfUEFSVElB",
+            "TBACIpADChZDaGVja1Blcm1pc3Npb25SZXF1ZXN0Ej0KC2NvbnNpc3RlbmN5",
+            "GAEgASgLMhsuYXV0aHplZC5hcGkudjEuQ29uc2lzdGVuY3lSC2NvbnNpc3Rl",
+            "bmN5EkUKCHJlc291cmNlGAIgASgLMh8uYXV0aHplZC5hcGkudjEuT2JqZWN0",
+            "UmVmZXJlbmNlQgj6QgWKAQIQAVIIcmVzb3VyY2USSgoKcGVybWlzc2lvbhgD",
+            "IAEoCUIq+kInciUoQDIhXihbYS16XVthLXowLTlfXXsxLDYyfVthLXowLTld",
+            "KT8kUgpwZXJtaXNzaW9uEkQKB3N1YmplY3QYBCABKAsyIC5hdXRoemVkLmFw",
+            "aS52MS5TdWJqZWN0UmVmZXJlbmNlQgj6QgWKAQIQAVIHc3ViamVjdBI7Cgdj",
+            "b250ZXh0GAUgASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdEII+kIFigEC",
+            "EABSB2NvbnRleHQSIQoMd2l0aF90cmFjaW5nGAYgASgIUgt3aXRoVHJhY2lu",
+            "ZyKLBAoXQ2hlY2tQZXJtaXNzaW9uUmVzcG9uc2USQQoKY2hlY2tlZF9hdBgB",
+            "IAEoCzIYLmF1dGh6ZWQuYXBpLnYxLlplZFRva2VuQgj6QgWKAQIQAFIJY2hl",
+            "Y2tlZEF0EmoKDnBlcm1pc3Npb25zaGlwGAIgASgOMjYuYXV0aHplZC5hcGku",
+            "djEuQ2hlY2tQZXJtaXNzaW9uUmVzcG9uc2UuUGVybWlzc2lvbnNoaXBCCvpC",
+            "B4IBBBABIABSDnBlcm1pc3Npb25zaGlwElsKE3BhcnRpYWxfY2F2ZWF0X2lu",
+            "Zm8YAyABKAsyIS5hdXRoemVkLmFwaS52MS5QYXJ0aWFsQ2F2ZWF0SW5mb0II",
+            "+kIFigECEABSEXBhcnRpYWxDYXZlYXRJbmZvEkEKC2RlYnVnX3RyYWNlGAQg",
+            "ASgLMiAuYXV0aHplZC5hcGkudjEuRGVidWdJbmZvcm1hdGlvblIKZGVidWdU",
+            "cmFjZSKgAQoOUGVybWlzc2lvbnNoaXASHgoaUEVSTUlTU0lPTlNISVBfVU5T",
+            "UEVDSUZJRUQQABIgChxQRVJNSVNTSU9OU0hJUF9OT19QRVJNSVNTSU9OEAES",
+            "IQodUEVSTUlTU0lPTlNISVBfSEFTX1BFUk1JU1NJT04QAhIpCiVQRVJNSVNT",
+            "SU9OU0hJUF9DT05ESVRJT05BTF9QRVJNSVNTSU9OEAMisgEKG0NoZWNrQnVs",
+            "a1Blcm1pc3Npb25zUmVxdWVzdBI9Cgtjb25zaXN0ZW5jeRgBIAEoCzIbLmF1",
+            "dGh6ZWQuYXBpLnYxLkNvbnNpc3RlbmN5Ugtjb25zaXN0ZW5jeRJUCgVpdGVt",
+            "cxgCIAMoCzIvLmF1dGh6ZWQuYXBpLnYxLkNoZWNrQnVsa1Blcm1pc3Npb25z",
+            "UmVxdWVzdEl0ZW1CDfpCCpIBByIFigECEAFSBWl0ZW1zIrcCCh9DaGVja0J1",
+            "bGtQZXJtaXNzaW9uc1JlcXVlc3RJdGVtEkUKCHJlc291cmNlGAEgASgLMh8u",
+            "YXV0aHplZC5hcGkudjEuT2JqZWN0UmVmZXJlbmNlQgj6QgWKAQIQAVIIcmVz",
+            "b3VyY2USSgoKcGVybWlzc2lvbhgCIAEoCUIq+kInciUoQDIhXihbYS16XVth",
+            "LXowLTlfXXsxLDYyfVthLXowLTldKT8kUgpwZXJtaXNzaW9uEkQKB3N1Ympl",
+            "Y3QYAyABKAsyIC5hdXRoemVkLmFwaS52MS5TdWJqZWN0UmVmZXJlbmNlQgj6",
+            "QgWKAQIQAVIHc3ViamVjdBI7Cgdjb250ZXh0GAQgASgLMhcuZ29vZ2xlLnBy",
+            "b3RvYnVmLlN0cnVjdEII+kIFigECEABSB2NvbnRleHQisAEKHENoZWNrQnVs",
+            "a1Blcm1pc3Npb25zUmVzcG9uc2USQQoKY2hlY2tlZF9hdBgBIAEoCzIYLmF1",
+            "dGh6ZWQuYXBpLnYxLlplZFRva2VuQgj6QgWKAQIQAFIJY2hlY2tlZEF0Ek0K",
+            "BXBhaXJzGAIgAygLMiguYXV0aHplZC5hcGkudjEuQ2hlY2tCdWxrUGVybWlz",
+            "c2lvbnNQYWlyQg36QgqSAQciBYoBAhABUgVwYWlycyLlAQoYQ2hlY2tCdWxr",
+            "UGVybWlzc2lvbnNQYWlyEkkKB3JlcXVlc3QYASABKAsyLy5hdXRoemVkLmFw",
+            "aS52MS5DaGVja0J1bGtQZXJtaXNzaW9uc1JlcXVlc3RJdGVtUgdyZXF1ZXN0",
+            "EkYKBGl0ZW0YAiABKAsyMC5hdXRoemVkLmFwaS52MS5DaGVja0J1bGtQZXJt",
+            "aXNzaW9uc1Jlc3BvbnNlSXRlbUgAUgRpdGVtEioKBWVycm9yGAMgASgLMhIu",
+            "Z29vZ2xlLnJwYy5TdGF0dXNIAFIFZXJyb3JCCgoIcmVzcG9uc2Ui6wEKIENo",
+            "ZWNrQnVsa1Blcm1pc3Npb25zUmVzcG9uc2VJdGVtEmoKDnBlcm1pc3Npb25z",
+            "aGlwGAEgASgOMjYuYXV0aHplZC5hcGkudjEuQ2hlY2tQZXJtaXNzaW9uUmVz",
+            "cG9uc2UuUGVybWlzc2lvbnNoaXBCCvpCB4IBBBABIABSDnBlcm1pc3Npb25z",
+            "aGlwElsKE3BhcnRpYWxfY2F2ZWF0X2luZm8YAiABKAsyIS5hdXRoemVkLmFw",
+            "aS52MS5QYXJ0aWFsQ2F2ZWF0SW5mb0II+kIFigECEABSEXBhcnRpYWxDYXZl",
+            "YXRJbmZvIu8BChtFeHBhbmRQZXJtaXNzaW9uVHJlZVJlcXVlc3QSPQoLY29u",
             "c2lzdGVuY3kYASABKAsyGy5hdXRoemVkLmFwaS52MS5Db25zaXN0ZW5jeVIL",
-            "Y29uc2lzdGVuY3kSVAoFaXRlbXMYAiADKAsyLy5hdXRoemVkLmFwaS52MS5D",
-            "aGVja0J1bGtQZXJtaXNzaW9uc1JlcXVlc3RJdGVtQg36QgqSAQciBYoBAhAB",
-            "UgVpdGVtcyK3AgofQ2hlY2tCdWxrUGVybWlzc2lvbnNSZXF1ZXN0SXRlbRJF",
-            "CghyZXNvdXJjZRgBIAEoCzIfLmF1dGh6ZWQuYXBpLnYxLk9iamVjdFJlZmVy",
-            "ZW5jZUII+kIFigECEAFSCHJlc291cmNlEkoKCnBlcm1pc3Npb24YAiABKAlC",
-            "KvpCJ3IlKEAyIV4oW2Etel1bYS16MC05X117MSw2Mn1bYS16MC05XSk/JFIK",
-            "cGVybWlzc2lvbhJECgdzdWJqZWN0GAMgASgLMiAuYXV0aHplZC5hcGkudjEu",
-            "U3ViamVjdFJlZmVyZW5jZUII+kIFigECEAFSB3N1YmplY3QSOwoHY29udGV4",
-            "dBgEIAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1Y3RCCPpCBYoBAhAAUgdj",
-            "b250ZXh0IrABChxDaGVja0J1bGtQZXJtaXNzaW9uc1Jlc3BvbnNlEkEKCmNo",
-            "ZWNrZWRfYXQYASABKAsyGC5hdXRoemVkLmFwaS52MS5aZWRUb2tlbkII+kIF",
-            "igECEABSCWNoZWNrZWRBdBJNCgVwYWlycxgCIAMoCzIoLmF1dGh6ZWQuYXBp",
-            "LnYxLkNoZWNrQnVsa1Blcm1pc3Npb25zUGFpckIN+kIKkgEHIgWKAQIQAVIF",
-            "cGFpcnMi5QEKGENoZWNrQnVsa1Blcm1pc3Npb25zUGFpchJJCgdyZXF1ZXN0",
-            "GAEgASgLMi8uYXV0aHplZC5hcGkudjEuQ2hlY2tCdWxrUGVybWlzc2lvbnNS",
-            "ZXF1ZXN0SXRlbVIHcmVxdWVzdBJGCgRpdGVtGAIgASgLMjAuYXV0aHplZC5h",
-            "cGkudjEuQ2hlY2tCdWxrUGVybWlzc2lvbnNSZXNwb25zZUl0ZW1IAFIEaXRl",
-            "bRIqCgVlcnJvchgDIAEoCzISLmdvb2dsZS5ycGMuU3RhdHVzSABSBWVycm9y",
-            "QgoKCHJlc3BvbnNlIusBCiBDaGVja0J1bGtQZXJtaXNzaW9uc1Jlc3BvbnNl",
-            "SXRlbRJqCg5wZXJtaXNzaW9uc2hpcBgBIAEoDjI2LmF1dGh6ZWQuYXBpLnYx",
-            "LkNoZWNrUGVybWlzc2lvblJlc3BvbnNlLlBlcm1pc3Npb25zaGlwQgr6QgeC",
-            "AQQQASAAUg5wZXJtaXNzaW9uc2hpcBJbChNwYXJ0aWFsX2NhdmVhdF9pbmZv",
-            "GAIgASgLMiEuYXV0aHplZC5hcGkudjEuUGFydGlhbENhdmVhdEluZm9CCPpC",
-            "BYoBAhAAUhFwYXJ0aWFsQ2F2ZWF0SW5mbyLvAQobRXhwYW5kUGVybWlzc2lv",
-            "blRyZWVSZXF1ZXN0Ej0KC2NvbnNpc3RlbmN5GAEgASgLMhsuYXV0aHplZC5h",
-            "cGkudjEuQ29uc2lzdGVuY3lSC2NvbnNpc3RlbmN5EkUKCHJlc291cmNlGAIg",
-            "ASgLMh8uYXV0aHplZC5hcGkudjEuT2JqZWN0UmVmZXJlbmNlQgj6QgWKAQIQ",
-            "AVIIcmVzb3VyY2USSgoKcGVybWlzc2lvbhgDIAEoCUIq+kInciUoQDIhXihb",
-            "YS16XVthLXowLTlfXXsxLDYyfVthLXowLTldKT8kUgpwZXJtaXNzaW9uIqIB",
-            "ChxFeHBhbmRQZXJtaXNzaW9uVHJlZVJlc3BvbnNlEjkKC2V4cGFuZGVkX2F0",
-            "GAEgASgLMhguYXV0aHplZC5hcGkudjEuWmVkVG9rZW5SCmV4cGFuZGVkQXQS",
-            "RwoJdHJlZV9yb290GAIgASgLMiouYXV0aHplZC5hcGkudjEuUGVybWlzc2lv",
-            "blJlbGF0aW9uc2hpcFRyZWVSCHRyZWVSb290IpAEChZMb29rdXBSZXNvdXJj",
-            "ZXNSZXF1ZXN0Ej0KC2NvbnNpc3RlbmN5GAEgASgLMhsuYXV0aHplZC5hcGku",
-            "djEuQ29uc2lzdGVuY3lSC2NvbnNpc3RlbmN5EnoKFHJlc291cmNlX29iamVj",
-            "dF90eXBlGAIgASgJQkj6QkVyQyiAATI+XihbYS16XVthLXowLTlfXXsxLDYx",
-            "fVthLXowLTldLykqW2Etel1bYS16MC05X117MSw2Mn1bYS16MC05XSRSEnJl",
-            "c291cmNlT2JqZWN0VHlwZRJHCgpwZXJtaXNzaW9uGAMgASgJQif6QiRyIihA",
-            "Mh5eW2Etel1bYS16MC05X117MSw2Mn1bYS16MC05XSRSCnBlcm1pc3Npb24S",
-            "RAoHc3ViamVjdBgEIAEoCzIgLmF1dGh6ZWQuYXBpLnYxLlN1YmplY3RSZWZl",
-            "cmVuY2VCCPpCBYoBAhABUgdzdWJqZWN0EjsKB2NvbnRleHQYBSABKAsyFy5n",
-            "b29nbGUucHJvdG9idWYuU3RydWN0Qgj6QgWKAQIQAFIHY29udGV4dBIuCg5v",
-            "cHRpb25hbF9saW1pdBgGIAEoDUIH+kIEKgIoAFINb3B0aW9uYWxMaW1pdBI/",
-            "Cg9vcHRpb25hbF9jdXJzb3IYByABKAsyFi5hdXRoemVkLmFwaS52MS5DdXJz",
-            "b3JSDm9wdGlvbmFsQ3Vyc29yIoIDChdMb29rdXBSZXNvdXJjZXNSZXNwb25z",
-            "ZRI6Cgxsb29rZWRfdXBfYXQYASABKAsyGC5hdXRoemVkLmFwaS52MS5aZWRU",
-            "b2tlblIKbG9va2VkVXBBdBIsChJyZXNvdXJjZV9vYmplY3RfaWQYAiABKAlS",
-            "EHJlc291cmNlT2JqZWN0SWQSWAoOcGVybWlzc2lvbnNoaXAYAyABKA4yJC5h",
-            "dXRoemVkLmFwaS52MS5Mb29rdXBQZXJtaXNzaW9uc2hpcEIK+kIHggEEEAEg",
-            "AFIOcGVybWlzc2lvbnNoaXASWwoTcGFydGlhbF9jYXZlYXRfaW5mbxgEIAEo",
-            "CzIhLmF1dGh6ZWQuYXBpLnYxLlBhcnRpYWxDYXZlYXRJbmZvQgj6QgWKAQIQ",
-            "AFIRcGFydGlhbENhdmVhdEluZm8SRgoTYWZ0ZXJfcmVzdWx0X2N1cnNvchgF",
-            "IAEoCzIWLmF1dGh6ZWQuYXBpLnYxLkN1cnNvclIRYWZ0ZXJSZXN1bHRDdXJz",
-            "b3Ii6gYKFUxvb2t1cFN1YmplY3RzUmVxdWVzdBI9Cgtjb25zaXN0ZW5jeRgB",
-            "IAEoCzIbLmF1dGh6ZWQuYXBpLnYxLkNvbnNpc3RlbmN5Ugtjb25zaXN0ZW5j",
-            "eRJFCghyZXNvdXJjZRgCIAEoCzIfLmF1dGh6ZWQuYXBpLnYxLk9iamVjdFJl",
-            "ZmVyZW5jZUII+kIFigECEAFSCHJlc291cmNlEkoKCnBlcm1pc3Npb24YAyAB",
-            "KAlCKvpCJ3IlKEAyIV4oW2Etel1bYS16MC05X117MSw2Mn1bYS16MC05XSk/",
-            "JFIKcGVybWlzc2lvbhJ4ChNzdWJqZWN0X29iamVjdF90eXBlGAQgASgJQkj6",
-            "QkVyQyiAATI+XihbYS16XVthLXowLTlfXXsxLDYxfVthLXowLTldLykqW2Et",
-            "el1bYS16MC05X117MSw2Mn1bYS16MC05XSRSEXN1YmplY3RPYmplY3RUeXBl",
-            "EmYKGW9wdGlvbmFsX3N1YmplY3RfcmVsYXRpb24YBSABKAlCKvpCJ3IlKEAy",
-            "IV4oW2Etel1bYS16MC05X117MSw2Mn1bYS16MC05XSk/JFIXb3B0aW9uYWxT",
-            "dWJqZWN0UmVsYXRpb24SOwoHY29udGV4dBgGIAEoCzIXLmdvb2dsZS5wcm90",
-            "b2J1Zi5TdHJ1Y3RCCPpCBYoBAhAAUgdjb250ZXh0Ej8KF29wdGlvbmFsX2Nv",
-            "bmNyZXRlX2xpbWl0GAcgASgNQgf6QgQqAigAUhVvcHRpb25hbENvbmNyZXRl",
-            "TGltaXQSPwoPb3B0aW9uYWxfY3Vyc29yGAggASgLMhYuYXV0aHplZC5hcGku",
-            "djEuQ3Vyc29yUg5vcHRpb25hbEN1cnNvchJdCg93aWxkY2FyZF9vcHRpb24Y",
-            "CSABKA4yNC5hdXRoemVkLmFwaS52MS5Mb29rdXBTdWJqZWN0c1JlcXVlc3Qu",
-            "V2lsZGNhcmRPcHRpb25SDndpbGRjYXJkT3B0aW9uIn8KDldpbGRjYXJkT3B0",
-            "aW9uEh8KG1dJTERDQVJEX09QVElPTl9VTlNQRUNJRklFRBAAEiUKIVdJTERD",
-            "QVJEX09QVElPTl9JTkNMVURFX1dJTERDQVJEUxABEiUKIVdJTERDQVJEX09Q",
-            "VElPTl9FWENMVURFX1dJTERDQVJEUxACIsYEChZMb29rdXBTdWJqZWN0c1Jl",
-            "c3BvbnNlEjoKDGxvb2tlZF91cF9hdBgBIAEoCzIYLmF1dGh6ZWQuYXBpLnYx",
-            "LlplZFRva2VuUgpsb29rZWRVcEF0Ei4KEXN1YmplY3Rfb2JqZWN0X2lkGAIg",
-            "ASgJQgIYAVIPc3ViamVjdE9iamVjdElkEjQKFGV4Y2x1ZGVkX3N1YmplY3Rf",
-            "aWRzGAMgAygJQgIYAVISZXhjbHVkZWRTdWJqZWN0SWRzEloKDnBlcm1pc3Np",
-            "b25zaGlwGAQgASgOMiQuYXV0aHplZC5hcGkudjEuTG9va3VwUGVybWlzc2lv",
-            "bnNoaXBCDBgB+kIHggEEEAEgAFIOcGVybWlzc2lvbnNoaXASXQoTcGFydGlh",
-            "bF9jYXZlYXRfaW5mbxgFIAEoCzIhLmF1dGh6ZWQuYXBpLnYxLlBhcnRpYWxD",
-            "YXZlYXRJbmZvQgoYAfpCBYoBAhAAUhFwYXJ0aWFsQ2F2ZWF0SW5mbxI5Cgdz",
-            "dWJqZWN0GAYgASgLMh8uYXV0aHplZC5hcGkudjEuUmVzb2x2ZWRTdWJqZWN0",
-            "UgdzdWJqZWN0EkwKEWV4Y2x1ZGVkX3N1YmplY3RzGAcgAygLMh8uYXV0aHpl",
-            "ZC5hcGkudjEuUmVzb2x2ZWRTdWJqZWN0UhBleGNsdWRlZFN1YmplY3RzEkYK",
-            "E2FmdGVyX3Jlc3VsdF9jdXJzb3IYCCABKAsyFi5hdXRoemVkLmFwaS52MS5D",
-            "dXJzb3JSEWFmdGVyUmVzdWx0Q3Vyc29yIvQBCg9SZXNvbHZlZFN1YmplY3QS",
-            "KgoRc3ViamVjdF9vYmplY3RfaWQYASABKAlSD3N1YmplY3RPYmplY3RJZBJY",
-            "Cg5wZXJtaXNzaW9uc2hpcBgCIAEoDjIkLmF1dGh6ZWQuYXBpLnYxLkxvb2t1",
+            "Y29uc2lzdGVuY3kSRQoIcmVzb3VyY2UYAiABKAsyHy5hdXRoemVkLmFwaS52",
+            "MS5PYmplY3RSZWZlcmVuY2VCCPpCBYoBAhABUghyZXNvdXJjZRJKCgpwZXJt",
+            "aXNzaW9uGAMgASgJQir6QidyJShAMiFeKFthLXpdW2EtejAtOV9dezEsNjJ9",
+            "W2EtejAtOV0pPyRSCnBlcm1pc3Npb24iogEKHEV4cGFuZFBlcm1pc3Npb25U",
+            "cmVlUmVzcG9uc2USOQoLZXhwYW5kZWRfYXQYASABKAsyGC5hdXRoemVkLmFw",
+            "aS52MS5aZWRUb2tlblIKZXhwYW5kZWRBdBJHCgl0cmVlX3Jvb3QYAiABKAsy",
+            "Ki5hdXRoemVkLmFwaS52MS5QZXJtaXNzaW9uUmVsYXRpb25zaGlwVHJlZVII",
+            "dHJlZVJvb3QikAQKFkxvb2t1cFJlc291cmNlc1JlcXVlc3QSPQoLY29uc2lz",
+            "dGVuY3kYASABKAsyGy5hdXRoemVkLmFwaS52MS5Db25zaXN0ZW5jeVILY29u",
+            "c2lzdGVuY3kSegoUcmVzb3VyY2Vfb2JqZWN0X3R5cGUYAiABKAlCSPpCRXJD",
+            "KIABMj5eKFthLXpdW2EtejAtOV9dezEsNjF9W2EtejAtOV0vKSpbYS16XVth",
+            "LXowLTlfXXsxLDYyfVthLXowLTldJFIScmVzb3VyY2VPYmplY3RUeXBlEkcK",
+            "CnBlcm1pc3Npb24YAyABKAlCJ/pCJHIiKEAyHl5bYS16XVthLXowLTlfXXsx",
+            "LDYyfVthLXowLTldJFIKcGVybWlzc2lvbhJECgdzdWJqZWN0GAQgASgLMiAu",
+            "YXV0aHplZC5hcGkudjEuU3ViamVjdFJlZmVyZW5jZUII+kIFigECEAFSB3N1",
+            "YmplY3QSOwoHY29udGV4dBgFIAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1",
+            "Y3RCCPpCBYoBAhAAUgdjb250ZXh0Ei4KDm9wdGlvbmFsX2xpbWl0GAYgASgN",
+            "Qgf6QgQqAigAUg1vcHRpb25hbExpbWl0Ej8KD29wdGlvbmFsX2N1cnNvchgH",
+            "IAEoCzIWLmF1dGh6ZWQuYXBpLnYxLkN1cnNvclIOb3B0aW9uYWxDdXJzb3Ii",
+            "ggMKF0xvb2t1cFJlc291cmNlc1Jlc3BvbnNlEjoKDGxvb2tlZF91cF9hdBgB",
+            "IAEoCzIYLmF1dGh6ZWQuYXBpLnYxLlplZFRva2VuUgpsb29rZWRVcEF0EiwK",
+            "EnJlc291cmNlX29iamVjdF9pZBgCIAEoCVIQcmVzb3VyY2VPYmplY3RJZBJY",
+            "Cg5wZXJtaXNzaW9uc2hpcBgDIAEoDjIkLmF1dGh6ZWQuYXBpLnYxLkxvb2t1",
             "cFBlcm1pc3Npb25zaGlwQgr6QgeCAQQQASAAUg5wZXJtaXNzaW9uc2hpcBJb",
-            "ChNwYXJ0aWFsX2NhdmVhdF9pbmZvGAMgASgLMiEuYXV0aHplZC5hcGkudjEu",
+            "ChNwYXJ0aWFsX2NhdmVhdF9pbmZvGAQgASgLMiEuYXV0aHplZC5hcGkudjEu",
             "UGFydGlhbENhdmVhdEluZm9CCPpCBYoBAhAAUhFwYXJ0aWFsQ2F2ZWF0SW5m",
-            "byJzCh5JbXBvcnRCdWxrUmVsYXRpb25zaGlwc1JlcXVlc3QSUQoNcmVsYXRp",
-            "b25zaGlwcxgBIAMoCzIcLmF1dGh6ZWQuYXBpLnYxLlJlbGF0aW9uc2hpcEIN",
-            "+kIKkgEHIgWKAQIQAVINcmVsYXRpb25zaGlwcyJACh9JbXBvcnRCdWxrUmVs",
-            "YXRpb25zaGlwc1Jlc3BvbnNlEh0KCm51bV9sb2FkZWQYASABKARSCW51bUxv",
-            "YWRlZCK2AgoeRXhwb3J0QnVsa1JlbGF0aW9uc2hpcHNSZXF1ZXN0Ej0KC2Nv",
-            "bnNpc3RlbmN5GAEgASgLMhsuYXV0aHplZC5hcGkudjEuQ29uc2lzdGVuY3lS",
-            "C2NvbnNpc3RlbmN5Ei4KDm9wdGlvbmFsX2xpbWl0GAIgASgNQgf6QgQqAigA",
-            "Ug1vcHRpb25hbExpbWl0Ej8KD29wdGlvbmFsX2N1cnNvchgDIAEoCzIWLmF1",
-            "dGh6ZWQuYXBpLnYxLkN1cnNvclIOb3B0aW9uYWxDdXJzb3ISZAocb3B0aW9u",
-            "YWxfcmVsYXRpb25zaGlwX2ZpbHRlchgEIAEoCzIiLmF1dGh6ZWQuYXBpLnYx",
-            "LlJlbGF0aW9uc2hpcEZpbHRlclIab3B0aW9uYWxSZWxhdGlvbnNoaXBGaWx0",
-            "ZXIirQEKH0V4cG9ydEJ1bGtSZWxhdGlvbnNoaXBzUmVzcG9uc2USRgoTYWZ0",
-            "ZXJfcmVzdWx0X2N1cnNvchgBIAEoCzIWLmF1dGh6ZWQuYXBpLnYxLkN1cnNv",
-            "clIRYWZ0ZXJSZXN1bHRDdXJzb3ISQgoNcmVsYXRpb25zaGlwcxgCIAMoCzIc",
-            "LmF1dGh6ZWQuYXBpLnYxLlJlbGF0aW9uc2hpcFINcmVsYXRpb25zaGlwcyqZ",
-            "AQoUTG9va3VwUGVybWlzc2lvbnNoaXASJQohTE9PS1VQX1BFUk1JU1NJT05T",
-            "SElQX1VOU1BFQ0lGSUVEEAASKAokTE9PS1VQX1BFUk1JU1NJT05TSElQX0hB",
-            "U19QRVJNSVNTSU9OEAESMAosTE9PS1VQX1BFUk1JU1NJT05TSElQX0NPTkRJ",
-            "VElPTkFMX1BFUk1JU1NJT04QAjKEDAoSUGVybWlzc2lvbnNTZXJ2aWNlEo0B",
-            "ChFSZWFkUmVsYXRpb25zaGlwcxIoLmF1dGh6ZWQuYXBpLnYxLlJlYWRSZWxh",
-            "dGlvbnNoaXBzUmVxdWVzdBopLmF1dGh6ZWQuYXBpLnYxLlJlYWRSZWxhdGlv",
-            "bnNoaXBzUmVzcG9uc2UiIYLT5JMCGzoBKiIWL3YxL3JlbGF0aW9uc2hpcHMv",
-            "cmVhZDABEo8BChJXcml0ZVJlbGF0aW9uc2hpcHMSKS5hdXRoemVkLmFwaS52",
-            "MS5Xcml0ZVJlbGF0aW9uc2hpcHNSZXF1ZXN0GiouYXV0aHplZC5hcGkudjEu",
-            "V3JpdGVSZWxhdGlvbnNoaXBzUmVzcG9uc2UiIoLT5JMCHDoBKiIXL3YxL3Jl",
-            "bGF0aW9uc2hpcHMvd3JpdGUSkwEKE0RlbGV0ZVJlbGF0aW9uc2hpcHMSKi5h",
-            "dXRoemVkLmFwaS52MS5EZWxldGVSZWxhdGlvbnNoaXBzUmVxdWVzdBorLmF1",
-            "dGh6ZWQuYXBpLnYxLkRlbGV0ZVJlbGF0aW9uc2hpcHNSZXNwb25zZSIjgtPk",
-            "kwIdOgEqIhgvdjEvcmVsYXRpb25zaGlwcy9kZWxldGUShAEKD0NoZWNrUGVy",
-            "bWlzc2lvbhImLmF1dGh6ZWQuYXBpLnYxLkNoZWNrUGVybWlzc2lvblJlcXVl",
-            "c3QaJy5hdXRoemVkLmFwaS52MS5DaGVja1Blcm1pc3Npb25SZXNwb25zZSIg",
-            "gtPkkwIaOgEqIhUvdjEvcGVybWlzc2lvbnMvY2hlY2sSlwEKFENoZWNrQnVs",
-            "a1Blcm1pc3Npb25zEisuYXV0aHplZC5hcGkudjEuQ2hlY2tCdWxrUGVybWlz",
-            "c2lvbnNSZXF1ZXN0GiwuYXV0aHplZC5hcGkudjEuQ2hlY2tCdWxrUGVybWlz",
-            "c2lvbnNSZXNwb25zZSIkgtPkkwIeOgEqIhkvdjEvcGVybWlzc2lvbnMvY2hl",
-            "Y2tidWxrEpQBChRFeHBhbmRQZXJtaXNzaW9uVHJlZRIrLmF1dGh6ZWQuYXBp",
-            "LnYxLkV4cGFuZFBlcm1pc3Npb25UcmVlUmVxdWVzdBosLmF1dGh6ZWQuYXBp",
-            "LnYxLkV4cGFuZFBlcm1pc3Npb25UcmVlUmVzcG9uc2UiIYLT5JMCGzoBKiIW",
-            "L3YxL3Blcm1pc3Npb25zL2V4cGFuZBKKAQoPTG9va3VwUmVzb3VyY2VzEiYu",
-            "YXV0aHplZC5hcGkudjEuTG9va3VwUmVzb3VyY2VzUmVxdWVzdBonLmF1dGh6",
-            "ZWQuYXBpLnYxLkxvb2t1cFJlc291cmNlc1Jlc3BvbnNlIiSC0+STAh46ASoi",
-            "GS92MS9wZXJtaXNzaW9ucy9yZXNvdXJjZXMwARKGAQoOTG9va3VwU3ViamVj",
-            "dHMSJS5hdXRoemVkLmFwaS52MS5Mb29rdXBTdWJqZWN0c1JlcXVlc3QaJi5h",
-            "dXRoemVkLmFwaS52MS5Mb29rdXBTdWJqZWN0c1Jlc3BvbnNlIiOC0+STAh06",
-            "ASoiGC92MS9wZXJtaXNzaW9ucy9zdWJqZWN0czABErIBChdJbXBvcnRCdWxr",
-            "UmVsYXRpb25zaGlwcxIuLmF1dGh6ZWQuYXBpLnYxLkltcG9ydEJ1bGtSZWxh",
-            "dGlvbnNoaXBzUmVxdWVzdBovLmF1dGh6ZWQuYXBpLnYxLkltcG9ydEJ1bGtS",
-            "ZWxhdGlvbnNoaXBzUmVzcG9uc2UiNILT5JMCLjoBKiIpL3YxL2V4cGVyaW1l",
-            "bnRhbC9yZWxhdGlvbnNoaXBzL2J1bGtpbXBvcnQoARKyAQoXRXhwb3J0QnVs",
-            "a1JlbGF0aW9uc2hpcHMSLi5hdXRoemVkLmFwaS52MS5FeHBvcnRCdWxrUmVs",
-            "YXRpb25zaGlwc1JlcXVlc3QaLy5hdXRoemVkLmFwaS52MS5FeHBvcnRCdWxr",
-            "UmVsYXRpb25zaGlwc1Jlc3BvbnNlIjSC0+STAi46ASoiKS92MS9leHBlcmlt",
-            "ZW50YWwvcmVsYXRpb25zaGlwcy9idWxrZXhwb3J0MAFCSgoSY29tLmF1dGh6",
-            "ZWQuYXBpLnYxUAFaMmdpdGh1Yi5jb20vYXV0aHplZC9hdXRoemVkLWdvL3By",
-            "b3RvL2F1dGh6ZWQvYXBpL3YxYgZwcm90bzM="));
+            "bxJGChNhZnRlcl9yZXN1bHRfY3Vyc29yGAUgASgLMhYuYXV0aHplZC5hcGku",
+            "djEuQ3Vyc29yUhFhZnRlclJlc3VsdEN1cnNvciLqBgoVTG9va3VwU3ViamVj",
+            "dHNSZXF1ZXN0Ej0KC2NvbnNpc3RlbmN5GAEgASgLMhsuYXV0aHplZC5hcGku",
+            "djEuQ29uc2lzdGVuY3lSC2NvbnNpc3RlbmN5EkUKCHJlc291cmNlGAIgASgL",
+            "Mh8uYXV0aHplZC5hcGkudjEuT2JqZWN0UmVmZXJlbmNlQgj6QgWKAQIQAVII",
+            "cmVzb3VyY2USSgoKcGVybWlzc2lvbhgDIAEoCUIq+kInciUoQDIhXihbYS16",
+            "XVthLXowLTlfXXsxLDYyfVthLXowLTldKT8kUgpwZXJtaXNzaW9uEngKE3N1",
+            "YmplY3Rfb2JqZWN0X3R5cGUYBCABKAlCSPpCRXJDKIABMj5eKFthLXpdW2Et",
+            "ejAtOV9dezEsNjF9W2EtejAtOV0vKSpbYS16XVthLXowLTlfXXsxLDYyfVth",
+            "LXowLTldJFIRc3ViamVjdE9iamVjdFR5cGUSZgoZb3B0aW9uYWxfc3ViamVj",
+            "dF9yZWxhdGlvbhgFIAEoCUIq+kInciUoQDIhXihbYS16XVthLXowLTlfXXsx",
+            "LDYyfVthLXowLTldKT8kUhdvcHRpb25hbFN1YmplY3RSZWxhdGlvbhI7Cgdj",
+            "b250ZXh0GAYgASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdEII+kIFigEC",
+            "EABSB2NvbnRleHQSPwoXb3B0aW9uYWxfY29uY3JldGVfbGltaXQYByABKA1C",
+            "B/pCBCoCKABSFW9wdGlvbmFsQ29uY3JldGVMaW1pdBI/Cg9vcHRpb25hbF9j",
+            "dXJzb3IYCCABKAsyFi5hdXRoemVkLmFwaS52MS5DdXJzb3JSDm9wdGlvbmFs",
+            "Q3Vyc29yEl0KD3dpbGRjYXJkX29wdGlvbhgJIAEoDjI0LmF1dGh6ZWQuYXBp",
+            "LnYxLkxvb2t1cFN1YmplY3RzUmVxdWVzdC5XaWxkY2FyZE9wdGlvblIOd2ls",
+            "ZGNhcmRPcHRpb24ifwoOV2lsZGNhcmRPcHRpb24SHwobV0lMRENBUkRfT1BU",
+            "SU9OX1VOU1BFQ0lGSUVEEAASJQohV0lMRENBUkRfT1BUSU9OX0lOQ0xVREVf",
+            "V0lMRENBUkRTEAESJQohV0lMRENBUkRfT1BUSU9OX0VYQ0xVREVfV0lMRENB",
+            "UkRTEAIixgQKFkxvb2t1cFN1YmplY3RzUmVzcG9uc2USOgoMbG9va2VkX3Vw",
+            "X2F0GAEgASgLMhguYXV0aHplZC5hcGkudjEuWmVkVG9rZW5SCmxvb2tlZFVw",
+            "QXQSLgoRc3ViamVjdF9vYmplY3RfaWQYAiABKAlCAhgBUg9zdWJqZWN0T2Jq",
+            "ZWN0SWQSNAoUZXhjbHVkZWRfc3ViamVjdF9pZHMYAyADKAlCAhgBUhJleGNs",
+            "dWRlZFN1YmplY3RJZHMSWgoOcGVybWlzc2lvbnNoaXAYBCABKA4yJC5hdXRo",
+            "emVkLmFwaS52MS5Mb29rdXBQZXJtaXNzaW9uc2hpcEIMGAH6QgeCAQQQASAA",
+            "Ug5wZXJtaXNzaW9uc2hpcBJdChNwYXJ0aWFsX2NhdmVhdF9pbmZvGAUgASgL",
+            "MiEuYXV0aHplZC5hcGkudjEuUGFydGlhbENhdmVhdEluZm9CChgB+kIFigEC",
+            "EABSEXBhcnRpYWxDYXZlYXRJbmZvEjkKB3N1YmplY3QYBiABKAsyHy5hdXRo",
+            "emVkLmFwaS52MS5SZXNvbHZlZFN1YmplY3RSB3N1YmplY3QSTAoRZXhjbHVk",
+            "ZWRfc3ViamVjdHMYByADKAsyHy5hdXRoemVkLmFwaS52MS5SZXNvbHZlZFN1",
+            "YmplY3RSEGV4Y2x1ZGVkU3ViamVjdHMSRgoTYWZ0ZXJfcmVzdWx0X2N1cnNv",
+            "chgIIAEoCzIWLmF1dGh6ZWQuYXBpLnYxLkN1cnNvclIRYWZ0ZXJSZXN1bHRD",
+            "dXJzb3Ii9AEKD1Jlc29sdmVkU3ViamVjdBIqChFzdWJqZWN0X29iamVjdF9p",
+            "ZBgBIAEoCVIPc3ViamVjdE9iamVjdElkElgKDnBlcm1pc3Npb25zaGlwGAIg",
+            "ASgOMiQuYXV0aHplZC5hcGkudjEuTG9va3VwUGVybWlzc2lvbnNoaXBCCvpC",
+            "B4IBBBABIABSDnBlcm1pc3Npb25zaGlwElsKE3BhcnRpYWxfY2F2ZWF0X2lu",
+            "Zm8YAyABKAsyIS5hdXRoemVkLmFwaS52MS5QYXJ0aWFsQ2F2ZWF0SW5mb0II",
+            "+kIFigECEABSEXBhcnRpYWxDYXZlYXRJbmZvInMKHkltcG9ydEJ1bGtSZWxh",
+            "dGlvbnNoaXBzUmVxdWVzdBJRCg1yZWxhdGlvbnNoaXBzGAEgAygLMhwuYXV0",
+            "aHplZC5hcGkudjEuUmVsYXRpb25zaGlwQg36QgqSAQciBYoBAhABUg1yZWxh",
+            "dGlvbnNoaXBzIkAKH0ltcG9ydEJ1bGtSZWxhdGlvbnNoaXBzUmVzcG9uc2US",
+            "HQoKbnVtX2xvYWRlZBgBIAEoBFIJbnVtTG9hZGVkIrYCCh5FeHBvcnRCdWxr",
+            "UmVsYXRpb25zaGlwc1JlcXVlc3QSPQoLY29uc2lzdGVuY3kYASABKAsyGy5h",
+            "dXRoemVkLmFwaS52MS5Db25zaXN0ZW5jeVILY29uc2lzdGVuY3kSLgoOb3B0",
+            "aW9uYWxfbGltaXQYAiABKA1CB/pCBCoCKABSDW9wdGlvbmFsTGltaXQSPwoP",
+            "b3B0aW9uYWxfY3Vyc29yGAMgASgLMhYuYXV0aHplZC5hcGkudjEuQ3Vyc29y",
+            "Ug5vcHRpb25hbEN1cnNvchJkChxvcHRpb25hbF9yZWxhdGlvbnNoaXBfZmls",
+            "dGVyGAQgASgLMiIuYXV0aHplZC5hcGkudjEuUmVsYXRpb25zaGlwRmlsdGVy",
+            "UhpvcHRpb25hbFJlbGF0aW9uc2hpcEZpbHRlciKtAQofRXhwb3J0QnVsa1Jl",
+            "bGF0aW9uc2hpcHNSZXNwb25zZRJGChNhZnRlcl9yZXN1bHRfY3Vyc29yGAEg",
+            "ASgLMhYuYXV0aHplZC5hcGkudjEuQ3Vyc29yUhFhZnRlclJlc3VsdEN1cnNv",
+            "chJCCg1yZWxhdGlvbnNoaXBzGAIgAygLMhwuYXV0aHplZC5hcGkudjEuUmVs",
+            "YXRpb25zaGlwUg1yZWxhdGlvbnNoaXBzKpkBChRMb29rdXBQZXJtaXNzaW9u",
+            "c2hpcBIlCiFMT09LVVBfUEVSTUlTU0lPTlNISVBfVU5TUEVDSUZJRUQQABIo",
+            "CiRMT09LVVBfUEVSTUlTU0lPTlNISVBfSEFTX1BFUk1JU1NJT04QARIwCixM",
+            "T09LVVBfUEVSTUlTU0lPTlNISVBfQ09ORElUSU9OQUxfUEVSTUlTU0lPThAC",
+            "MoQMChJQZXJtaXNzaW9uc1NlcnZpY2USjQEKEVJlYWRSZWxhdGlvbnNoaXBz",
+            "EiguYXV0aHplZC5hcGkudjEuUmVhZFJlbGF0aW9uc2hpcHNSZXF1ZXN0Giku",
+            "YXV0aHplZC5hcGkudjEuUmVhZFJlbGF0aW9uc2hpcHNSZXNwb25zZSIhgtPk",
+            "kwIbIhYvdjEvcmVsYXRpb25zaGlwcy9yZWFkOgEqMAESjwEKEldyaXRlUmVs",
+            "YXRpb25zaGlwcxIpLmF1dGh6ZWQuYXBpLnYxLldyaXRlUmVsYXRpb25zaGlw",
+            "c1JlcXVlc3QaKi5hdXRoemVkLmFwaS52MS5Xcml0ZVJlbGF0aW9uc2hpcHNS",
+            "ZXNwb25zZSIigtPkkwIcIhcvdjEvcmVsYXRpb25zaGlwcy93cml0ZToBKhKT",
+            "AQoTRGVsZXRlUmVsYXRpb25zaGlwcxIqLmF1dGh6ZWQuYXBpLnYxLkRlbGV0",
+            "ZVJlbGF0aW9uc2hpcHNSZXF1ZXN0GisuYXV0aHplZC5hcGkudjEuRGVsZXRl",
+            "UmVsYXRpb25zaGlwc1Jlc3BvbnNlIiOC0+STAh0iGC92MS9yZWxhdGlvbnNo",
+            "aXBzL2RlbGV0ZToBKhKEAQoPQ2hlY2tQZXJtaXNzaW9uEiYuYXV0aHplZC5h",
+            "cGkudjEuQ2hlY2tQZXJtaXNzaW9uUmVxdWVzdBonLmF1dGh6ZWQuYXBpLnYx",
+            "LkNoZWNrUGVybWlzc2lvblJlc3BvbnNlIiCC0+STAhoiFS92MS9wZXJtaXNz",
+            "aW9ucy9jaGVjazoBKhKXAQoUQ2hlY2tCdWxrUGVybWlzc2lvbnMSKy5hdXRo",
+            "emVkLmFwaS52MS5DaGVja0J1bGtQZXJtaXNzaW9uc1JlcXVlc3QaLC5hdXRo",
+            "emVkLmFwaS52MS5DaGVja0J1bGtQZXJtaXNzaW9uc1Jlc3BvbnNlIiSC0+ST",
+            "Ah4iGS92MS9wZXJtaXNzaW9ucy9jaGVja2J1bGs6ASoSlAEKFEV4cGFuZFBl",
+            "cm1pc3Npb25UcmVlEisuYXV0aHplZC5hcGkudjEuRXhwYW5kUGVybWlzc2lv",
+            "blRyZWVSZXF1ZXN0GiwuYXV0aHplZC5hcGkudjEuRXhwYW5kUGVybWlzc2lv",
+            "blRyZWVSZXNwb25zZSIhgtPkkwIbIhYvdjEvcGVybWlzc2lvbnMvZXhwYW5k",
+            "OgEqEooBCg9Mb29rdXBSZXNvdXJjZXMSJi5hdXRoemVkLmFwaS52MS5Mb29r",
+            "dXBSZXNvdXJjZXNSZXF1ZXN0GicuYXV0aHplZC5hcGkudjEuTG9va3VwUmVz",
+            "b3VyY2VzUmVzcG9uc2UiJILT5JMCHiIZL3YxL3Blcm1pc3Npb25zL3Jlc291",
+            "cmNlczoBKjABEoYBCg5Mb29rdXBTdWJqZWN0cxIlLmF1dGh6ZWQuYXBpLnYx",
+            "Lkxvb2t1cFN1YmplY3RzUmVxdWVzdBomLmF1dGh6ZWQuYXBpLnYxLkxvb2t1",
+            "cFN1YmplY3RzUmVzcG9uc2UiI4LT5JMCHSIYL3YxL3Blcm1pc3Npb25zL3N1",
+            "YmplY3RzOgEqMAESsgEKF0ltcG9ydEJ1bGtSZWxhdGlvbnNoaXBzEi4uYXV0",
+            "aHplZC5hcGkudjEuSW1wb3J0QnVsa1JlbGF0aW9uc2hpcHNSZXF1ZXN0Gi8u",
+            "YXV0aHplZC5hcGkudjEuSW1wb3J0QnVsa1JlbGF0aW9uc2hpcHNSZXNwb25z",
+            "ZSI0gtPkkwIuIikvdjEvZXhwZXJpbWVudGFsL3JlbGF0aW9uc2hpcHMvYnVs",
+            "a2ltcG9ydDoBKigBErIBChdFeHBvcnRCdWxrUmVsYXRpb25zaGlwcxIuLmF1",
+            "dGh6ZWQuYXBpLnYxLkV4cG9ydEJ1bGtSZWxhdGlvbnNoaXBzUmVxdWVzdBov",
+            "LmF1dGh6ZWQuYXBpLnYxLkV4cG9ydEJ1bGtSZWxhdGlvbnNoaXBzUmVzcG9u",
+            "c2UiNILT5JMCLiIpL3YxL2V4cGVyaW1lbnRhbC9yZWxhdGlvbnNoaXBzL2J1",
+            "bGtleHBvcnQ6ASowAUJKChJjb20uYXV0aHplZC5hcGkudjFQAVoyZ2l0aHVi",
+            "LmNvbS9hdXRoemVkL2F1dGh6ZWQtZ28vcHJvdG8vYXV0aHplZC9hcGkvdjFi",
+            "BnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Rpc.StatusReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, global::Authzed.Api.V1.CoreReflection.Descriptor, global::Authzed.Api.V1.DebugReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Authzed.Api.V1.LookupPermissionship), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -272,9 +277,9 @@ namespace Authzed.Api.V1 {
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.ReadRelationshipsRequest), global::Authzed.Api.V1.ReadRelationshipsRequest.Parser, new[]{ "Consistency", "RelationshipFilter", "OptionalLimit", "OptionalCursor" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.ReadRelationshipsResponse), global::Authzed.Api.V1.ReadRelationshipsResponse.Parser, new[]{ "ReadAt", "Relationship", "AfterResultCursor" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.Precondition), global::Authzed.Api.V1.Precondition.Parser, new[]{ "Operation", "Filter" }, null, new[]{ typeof(global::Authzed.Api.V1.Precondition.Types.Operation) }, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.WriteRelationshipsRequest), global::Authzed.Api.V1.WriteRelationshipsRequest.Parser, new[]{ "Updates", "OptionalPreconditions" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.WriteRelationshipsRequest), global::Authzed.Api.V1.WriteRelationshipsRequest.Parser, new[]{ "Updates", "OptionalPreconditions", "OptionalTransactionMetadata" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.WriteRelationshipsResponse), global::Authzed.Api.V1.WriteRelationshipsResponse.Parser, new[]{ "WrittenAt" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.DeleteRelationshipsRequest), global::Authzed.Api.V1.DeleteRelationshipsRequest.Parser, new[]{ "RelationshipFilter", "OptionalPreconditions", "OptionalLimit", "OptionalAllowPartialDeletions" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.DeleteRelationshipsRequest), global::Authzed.Api.V1.DeleteRelationshipsRequest.Parser, new[]{ "RelationshipFilter", "OptionalPreconditions", "OptionalLimit", "OptionalAllowPartialDeletions", "OptionalTransactionMetadata" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.DeleteRelationshipsResponse), global::Authzed.Api.V1.DeleteRelationshipsResponse.Parser, new[]{ "DeletedAt", "DeletionProgress" }, null, new[]{ typeof(global::Authzed.Api.V1.DeleteRelationshipsResponse.Types.DeletionProgress) }, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.CheckPermissionRequest), global::Authzed.Api.V1.CheckPermissionRequest.Parser, new[]{ "Consistency", "Resource", "Permission", "Subject", "Context", "WithTracing" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.CheckPermissionResponse), global::Authzed.Api.V1.CheckPermissionResponse.Parser, new[]{ "CheckedAt", "Permissionship", "PartialCaveatInfo", "DebugTrace" }, null, new[]{ typeof(global::Authzed.Api.V1.CheckPermissionResponse.Types.Permissionship) }, null, null),
@@ -317,6 +322,7 @@ namespace Authzed.Api.V1 {
   /// By defining a consistency requirement, and a token at which those
   /// requirements should be applied, where applicable.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Consistency : pb::IMessage<Consistency>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -384,10 +390,24 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public bool MinimizeLatency {
-      get { return requirementCase_ == RequirementOneofCase.MinimizeLatency ? (bool) requirement_ : false; }
+      get { return HasMinimizeLatency ? (bool) requirement_ : false; }
       set {
         requirement_ = value;
         requirementCase_ = RequirementOneofCase.MinimizeLatency;
+      }
+    }
+    /// <summary>Gets whether the "minimize_latency" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasMinimizeLatency {
+      get { return requirementCase_ == RequirementOneofCase.MinimizeLatency; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "minimize_latency" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearMinimizeLatency() {
+      if (HasMinimizeLatency) {
+        ClearRequirement();
       }
     }
 
@@ -438,10 +458,24 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public bool FullyConsistent {
-      get { return requirementCase_ == RequirementOneofCase.FullyConsistent ? (bool) requirement_ : false; }
+      get { return HasFullyConsistent ? (bool) requirement_ : false; }
       set {
         requirement_ = value;
         requirementCase_ = RequirementOneofCase.FullyConsistent;
+      }
+    }
+    /// <summary>Gets whether the "fully_consistent" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasFullyConsistent {
+      get { return requirementCase_ == RequirementOneofCase.FullyConsistent; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "fully_consistent" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearFullyConsistent() {
+      if (HasFullyConsistent) {
+        ClearRequirement();
       }
     }
 
@@ -495,10 +529,10 @@ namespace Authzed.Api.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
-      if (requirementCase_ == RequirementOneofCase.MinimizeLatency) hash ^= MinimizeLatency.GetHashCode();
+      if (HasMinimizeLatency) hash ^= MinimizeLatency.GetHashCode();
       if (requirementCase_ == RequirementOneofCase.AtLeastAsFresh) hash ^= AtLeastAsFresh.GetHashCode();
       if (requirementCase_ == RequirementOneofCase.AtExactSnapshot) hash ^= AtExactSnapshot.GetHashCode();
-      if (requirementCase_ == RequirementOneofCase.FullyConsistent) hash ^= FullyConsistent.GetHashCode();
+      if (HasFullyConsistent) hash ^= FullyConsistent.GetHashCode();
       hash ^= (int) requirementCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -518,7 +552,7 @@ namespace Authzed.Api.V1 {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (requirementCase_ == RequirementOneofCase.MinimizeLatency) {
+      if (HasMinimizeLatency) {
         output.WriteRawTag(8);
         output.WriteBool(MinimizeLatency);
       }
@@ -530,7 +564,7 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(26);
         output.WriteMessage(AtExactSnapshot);
       }
-      if (requirementCase_ == RequirementOneofCase.FullyConsistent) {
+      if (HasFullyConsistent) {
         output.WriteRawTag(32);
         output.WriteBool(FullyConsistent);
       }
@@ -544,7 +578,7 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (requirementCase_ == RequirementOneofCase.MinimizeLatency) {
+      if (HasMinimizeLatency) {
         output.WriteRawTag(8);
         output.WriteBool(MinimizeLatency);
       }
@@ -556,7 +590,7 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(26);
         output.WriteMessage(AtExactSnapshot);
       }
-      if (requirementCase_ == RequirementOneofCase.FullyConsistent) {
+      if (HasFullyConsistent) {
         output.WriteRawTag(32);
         output.WriteBool(FullyConsistent);
       }
@@ -570,7 +604,7 @@ namespace Authzed.Api.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
-      if (requirementCase_ == RequirementOneofCase.MinimizeLatency) {
+      if (HasMinimizeLatency) {
         size += 1 + 1;
       }
       if (requirementCase_ == RequirementOneofCase.AtLeastAsFresh) {
@@ -579,7 +613,7 @@ namespace Authzed.Api.V1 {
       if (requirementCase_ == RequirementOneofCase.AtExactSnapshot) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(AtExactSnapshot);
       }
-      if (requirementCase_ == RequirementOneofCase.FullyConsistent) {
+      if (HasFullyConsistent) {
         size += 1 + 1;
       }
       if (_unknownFields != null) {
@@ -626,7 +660,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -667,7 +705,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -715,6 +757,7 @@ namespace Authzed.Api.V1 {
   /// on which to filter. If a field is not indexed, the performance of the API
   /// can be significantly slower.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RelationshipFilter : pb::IMessage<RelationshipFilter>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1007,7 +1050,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1045,7 +1092,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1085,6 +1136,7 @@ namespace Authzed.Api.V1 {
   /// subject_type is required and all other fields are optional, and will not
   /// impose any additional requirements if left unspecified.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SubjectFilter : pb::IMessage<SubjectFilter>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1301,7 +1353,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1331,7 +1387,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1360,6 +1420,7 @@ namespace Authzed.Api.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static partial class Types {
+      [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
       public sealed partial class RelationFilter : pb::IMessage<RelationFilter>
       #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
           , pb::IBufferMessage
@@ -1515,7 +1576,11 @@ namespace Authzed.Api.V1 {
         #else
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
@@ -1534,7 +1599,11 @@ namespace Authzed.Api.V1 {
         void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
                 break;
@@ -1558,6 +1627,7 @@ namespace Authzed.Api.V1 {
   /// ReadRelationshipsRequest specifies one or more filters used to read matching
   /// relationships within the system.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadRelationshipsRequest : pb::IMessage<ReadRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1823,7 +1893,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1863,7 +1937,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1904,6 +1982,7 @@ namespace Authzed.Api.V1 {
   /// specified relationship filter(s). A instance of this response message will
   /// be streamed to the client for each relationship found.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadRelationshipsResponse : pb::IMessage<ReadRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2136,7 +2215,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2172,7 +2255,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2214,6 +2301,7 @@ namespace Authzed.Api.V1 {
   /// MUST_MATCH will fail the parent request if there are no
   /// relationships that match the filter.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Precondition : pb::IMessage<Precondition>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2401,7 +2489,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2427,7 +2519,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2467,8 +2563,10 @@ namespace Authzed.Api.V1 {
   /// WriteRelationshipsRequest contains a list of Relationship mutations that
   /// should be applied to the service. If the optional_preconditions parameter
   /// is included, all of the specified preconditions must also be satisfied before
-  /// the write will be committed.
+  /// the write will be committed. All updates will be applied transactionally,
+  /// and if any preconditions fail, the entire transaction will be reverted.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WriteRelationshipsRequest : pb::IMessage<WriteRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2505,6 +2603,7 @@ namespace Authzed.Api.V1 {
     public WriteRelationshipsRequest(WriteRelationshipsRequest other) : this() {
       updates_ = other.updates_.Clone();
       optionalPreconditions_ = other.optionalPreconditions_.Clone();
+      optionalTransactionMetadata_ = other.optionalTransactionMetadata_ != null ? other.optionalTransactionMetadata_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -2539,6 +2638,23 @@ namespace Authzed.Api.V1 {
       get { return optionalPreconditions_; }
     }
 
+    /// <summary>Field number for the "optional_transaction_metadata" field.</summary>
+    public const int OptionalTransactionMetadataFieldNumber = 3;
+    private global::Google.Protobuf.WellKnownTypes.Struct optionalTransactionMetadata_;
+    /// <summary>
+    /// optional_transaction_metadata is an optional field that can be used to store metadata about the transaction.
+    /// If specified, this metadata will be supplied in the WatchResponse for the updates associated with this
+    /// transaction.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.WellKnownTypes.Struct OptionalTransactionMetadata {
+      get { return optionalTransactionMetadata_; }
+      set {
+        optionalTransactionMetadata_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -2556,6 +2672,7 @@ namespace Authzed.Api.V1 {
       }
       if(!updates_.Equals(other.updates_)) return false;
       if(!optionalPreconditions_.Equals(other.optionalPreconditions_)) return false;
+      if (!object.Equals(OptionalTransactionMetadata, other.OptionalTransactionMetadata)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -2565,6 +2682,7 @@ namespace Authzed.Api.V1 {
       int hash = 1;
       hash ^= updates_.GetHashCode();
       hash ^= optionalPreconditions_.GetHashCode();
+      if (optionalTransactionMetadata_ != null) hash ^= OptionalTransactionMetadata.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -2585,6 +2703,10 @@ namespace Authzed.Api.V1 {
     #else
       updates_.WriteTo(output, _repeated_updates_codec);
       optionalPreconditions_.WriteTo(output, _repeated_optionalPreconditions_codec);
+      if (optionalTransactionMetadata_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(OptionalTransactionMetadata);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -2597,6 +2719,10 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
       updates_.WriteTo(ref output, _repeated_updates_codec);
       optionalPreconditions_.WriteTo(ref output, _repeated_optionalPreconditions_codec);
+      if (optionalTransactionMetadata_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(OptionalTransactionMetadata);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -2609,6 +2735,9 @@ namespace Authzed.Api.V1 {
       int size = 0;
       size += updates_.CalculateSize(_repeated_updates_codec);
       size += optionalPreconditions_.CalculateSize(_repeated_optionalPreconditions_codec);
+      if (optionalTransactionMetadata_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalTransactionMetadata);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -2623,6 +2752,12 @@ namespace Authzed.Api.V1 {
       }
       updates_.Add(other.updates_);
       optionalPreconditions_.Add(other.optionalPreconditions_);
+      if (other.optionalTransactionMetadata_ != null) {
+        if (optionalTransactionMetadata_ == null) {
+          OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+        }
+        OptionalTransactionMetadata.MergeFrom(other.OptionalTransactionMetadata);
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -2634,7 +2769,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2644,6 +2783,13 @@ namespace Authzed.Api.V1 {
           }
           case 18: {
             optionalPreconditions_.AddEntriesFrom(input, _repeated_optionalPreconditions_codec);
+            break;
+          }
+          case 26: {
+            if (optionalTransactionMetadata_ == null) {
+              OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+            }
+            input.ReadMessage(OptionalTransactionMetadata);
             break;
           }
         }
@@ -2657,7 +2803,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2669,6 +2819,13 @@ namespace Authzed.Api.V1 {
             optionalPreconditions_.AddEntriesFrom(ref input, _repeated_optionalPreconditions_codec);
             break;
           }
+          case 26: {
+            if (optionalTransactionMetadata_ == null) {
+              OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+            }
+            input.ReadMessage(OptionalTransactionMetadata);
+            break;
+          }
         }
       }
     }
@@ -2676,6 +2833,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WriteRelationshipsResponse : pb::IMessage<WriteRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2834,7 +2992,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2856,7 +3018,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2881,6 +3047,7 @@ namespace Authzed.Api.V1 {
   /// specified preconditions must also be satisfied before the delete will be
   /// executed.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DeleteRelationshipsRequest : pb::IMessage<DeleteRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2919,6 +3086,7 @@ namespace Authzed.Api.V1 {
       optionalPreconditions_ = other.optionalPreconditions_.Clone();
       optionalLimit_ = other.optionalLimit_;
       optionalAllowPartialDeletions_ = other.optionalAllowPartialDeletions_;
+      optionalTransactionMetadata_ = other.optionalTransactionMetadata_ != null ? other.optionalTransactionMetadata_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -2989,6 +3157,23 @@ namespace Authzed.Api.V1 {
       }
     }
 
+    /// <summary>Field number for the "optional_transaction_metadata" field.</summary>
+    public const int OptionalTransactionMetadataFieldNumber = 5;
+    private global::Google.Protobuf.WellKnownTypes.Struct optionalTransactionMetadata_;
+    /// <summary>
+    /// optional_transaction_metadata is an optional field that can be used to store metadata about the transaction.
+    /// If specified, this metadata will be supplied in the WatchResponse for the deletions associated with
+    /// this transaction.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.WellKnownTypes.Struct OptionalTransactionMetadata {
+      get { return optionalTransactionMetadata_; }
+      set {
+        optionalTransactionMetadata_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -3008,6 +3193,7 @@ namespace Authzed.Api.V1 {
       if(!optionalPreconditions_.Equals(other.optionalPreconditions_)) return false;
       if (OptionalLimit != other.OptionalLimit) return false;
       if (OptionalAllowPartialDeletions != other.OptionalAllowPartialDeletions) return false;
+      if (!object.Equals(OptionalTransactionMetadata, other.OptionalTransactionMetadata)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -3019,6 +3205,7 @@ namespace Authzed.Api.V1 {
       hash ^= optionalPreconditions_.GetHashCode();
       if (OptionalLimit != 0) hash ^= OptionalLimit.GetHashCode();
       if (OptionalAllowPartialDeletions != false) hash ^= OptionalAllowPartialDeletions.GetHashCode();
+      if (optionalTransactionMetadata_ != null) hash ^= OptionalTransactionMetadata.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -3050,6 +3237,10 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(32);
         output.WriteBool(OptionalAllowPartialDeletions);
       }
+      if (optionalTransactionMetadata_ != null) {
+        output.WriteRawTag(42);
+        output.WriteMessage(OptionalTransactionMetadata);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -3073,6 +3264,10 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(32);
         output.WriteBool(OptionalAllowPartialDeletions);
       }
+      if (optionalTransactionMetadata_ != null) {
+        output.WriteRawTag(42);
+        output.WriteMessage(OptionalTransactionMetadata);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -3092,6 +3287,9 @@ namespace Authzed.Api.V1 {
       }
       if (OptionalAllowPartialDeletions != false) {
         size += 1 + 1;
+      }
+      if (optionalTransactionMetadata_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalTransactionMetadata);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -3118,6 +3316,12 @@ namespace Authzed.Api.V1 {
       if (other.OptionalAllowPartialDeletions != false) {
         OptionalAllowPartialDeletions = other.OptionalAllowPartialDeletions;
       }
+      if (other.optionalTransactionMetadata_ != null) {
+        if (optionalTransactionMetadata_ == null) {
+          OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+        }
+        OptionalTransactionMetadata.MergeFrom(other.OptionalTransactionMetadata);
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -3129,7 +3333,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3152,6 +3360,13 @@ namespace Authzed.Api.V1 {
             OptionalAllowPartialDeletions = input.ReadBool();
             break;
           }
+          case 42: {
+            if (optionalTransactionMetadata_ == null) {
+              OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+            }
+            input.ReadMessage(OptionalTransactionMetadata);
+            break;
+          }
         }
       }
     #endif
@@ -3163,7 +3378,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3186,6 +3405,13 @@ namespace Authzed.Api.V1 {
             OptionalAllowPartialDeletions = input.ReadBool();
             break;
           }
+          case 42: {
+            if (optionalTransactionMetadata_ == null) {
+              OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+            }
+            input.ReadMessage(OptionalTransactionMetadata);
+            break;
+          }
         }
       }
     }
@@ -3193,6 +3419,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DeleteRelationshipsResponse : pb::IMessage<DeleteRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3386,7 +3613,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3412,7 +3643,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3462,6 +3697,7 @@ namespace Authzed.Api.V1 {
   /// CheckPermissionRequest issues a check on whether a subject has a permission
   /// or is a member of a relation, on a specific resource.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckPermissionRequest : pb::IMessage<CheckPermissionRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3792,7 +4028,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3843,7 +4083,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3890,6 +4134,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckPermissionResponse : pb::IMessage<CheckPermissionResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4157,7 +4402,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4197,7 +4446,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4255,6 +4508,7 @@ namespace Authzed.Api.V1 {
   /// The ordering of the items in the response is maintained in the response.
   /// Checks with the same subject/permission will automatically be batched for performance optimization.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckBulkPermissionsRequest : pb::IMessage<CheckBulkPermissionsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4431,7 +4685,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4457,7 +4715,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4479,6 +4741,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckBulkPermissionsRequestItem : pb::IMessage<CheckBulkPermissionsRequestItem>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4730,7 +4993,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4770,7 +5037,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4806,6 +5077,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckBulkPermissionsResponse : pb::IMessage<CheckBulkPermissionsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4982,7 +5254,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5008,7 +5284,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5030,6 +5310,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckBulkPermissionsPair : pb::IMessage<CheckBulkPermissionsPair>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5285,7 +5566,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5325,7 +5610,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5361,6 +5650,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CheckBulkPermissionsResponseItem : pb::IMessage<CheckBulkPermissionsResponseItem>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5548,7 +5838,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5574,7 +5868,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5605,6 +5903,7 @@ namespace Authzed.Api.V1 {
   /// subjects with a permission, along with the relationships that grant said
   /// access.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpandPermissionTreeRequest : pb::IMessage<ExpandPermissionTreeRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5831,7 +6130,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5864,7 +6167,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5893,6 +6200,7 @@ namespace Authzed.Api.V1 {
 
   }
 
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExpandPermissionTreeResponse : pb::IMessage<ExpandPermissionTreeResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6088,7 +6396,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6117,7 +6429,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6147,6 +6463,7 @@ namespace Authzed.Api.V1 {
   /// kind on which the subject has the specified permission or the relation in
   /// which the subject exists, streaming back the IDs of those resources.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupResourcesRequest : pb::IMessage<LookupResourcesRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6512,7 +6829,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6567,7 +6888,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6622,6 +6947,7 @@ namespace Authzed.Api.V1 {
   /// LookupResourcesResponse contains a single matching resource object ID for the
   /// requested object type, permission, and subject.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupResourcesResponse : pb::IMessage<LookupResourcesResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6918,7 +7244,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6962,7 +7292,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7007,6 +7341,7 @@ namespace Authzed.Api.V1 {
   /// kind for which the subject has the specified permission or the relation in
   /// which the subject exists, streaming back the IDs of those subjects.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupSubjectsRequest : pb::IMessage<LookupSubjectsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7456,7 +7791,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -7519,7 +7858,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7596,6 +7939,7 @@ namespace Authzed.Api.V1 {
   /// LookupSubjectsResponse contains a single matching subject object ID for the
   /// requested subject object type on the permission or relation.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class LookupSubjectsResponse : pb::IMessage<LookupSubjectsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7979,7 +8323,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8038,7 +8386,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8096,6 +8448,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ResolvedSubject is a single subject resolved within LookupSubjects.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ResolvedSubject : pb::IMessage<ResolvedSubject>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8322,7 +8675,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8352,7 +8709,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8384,6 +8745,7 @@ namespace Authzed.Api.V1 {
   /// datastore, and optimal size should be determined by the calling client
   /// experimentally.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ImportBulkRelationshipsRequest : pb::IMessage<ImportBulkRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8528,7 +8890,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8547,7 +8913,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8566,6 +8936,7 @@ namespace Authzed.Api.V1 {
   /// ImportBulkRelationshipsResponse is returned on successful completion of the
   /// bulk load stream, and contains the total number of relationships loaded.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ImportBulkRelationshipsResponse : pb::IMessage<ImportBulkRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8721,7 +9092,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8740,7 +9115,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8759,6 +9138,7 @@ namespace Authzed.Api.V1 {
   /// ExportBulkRelationshipsRequest represents a resumable request for
   /// all relationships from the server.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExportBulkRelationshipsRequest : pb::IMessage<ExportBulkRelationshipsRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -9025,7 +9405,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -9065,7 +9449,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -9107,6 +9495,7 @@ namespace Authzed.Api.V1 {
   /// server will continue to stream back relationship groups as quickly as it can
   /// until all relationships have been transmitted back.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExportBulkRelationshipsResponse : pb::IMessage<ExportBulkRelationshipsResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -9283,7 +9672,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -9309,7 +9702,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V1/PermissionServiceGrpc.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/PermissionServiceGrpc.cs
@@ -563,7 +563,8 @@ namespace Authzed.Api.V1 {
       /// performance, the caller should attempt to write relationships in as close
       /// to relationship sort order as possible: (resource.object_type,
       /// resource.object_id, relation, subject.object.object_type,
-      /// subject.object.object_id, subject.optional_relation)
+      /// subject.object.object_id, subject.optional_relation). All relationships
+      /// written are done so under a single transaction.
       /// </summary>
       /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
@@ -580,7 +581,8 @@ namespace Authzed.Api.V1 {
       /// performance, the caller should attempt to write relationships in as close
       /// to relationship sort order as possible: (resource.object_type,
       /// resource.object_id, relation, subject.object.object_type,
-      /// subject.object.object_id, subject.optional_relation)
+      /// subject.object.object_id, subject.optional_relation). All relationships
+      /// written are done so under a single transaction.
       /// </summary>
       /// <param name="options">The options for the call.</param>
       /// <returns>The call object.</returns>

--- a/src/Authzed.Net/Authzed/Api/V1/SchemaService.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/SchemaService.cs
@@ -35,10 +35,10 @@ namespace Authzed.Api.V1 {
             "dHRlbl9hdBgBIAEoCzIYLmF1dGh6ZWQuYXBpLnYxLlplZFRva2VuQgj6QgWK",
             "AQIQAVIJd3JpdHRlbkF0MvUBCg1TY2hlbWFTZXJ2aWNlEm8KClJlYWRTY2hl",
             "bWESIS5hdXRoemVkLmFwaS52MS5SZWFkU2NoZW1hUmVxdWVzdBoiLmF1dGh6",
-            "ZWQuYXBpLnYxLlJlYWRTY2hlbWFSZXNwb25zZSIagtPkkwIUOgEqIg8vdjEv",
-            "c2NoZW1hL3JlYWQScwoLV3JpdGVTY2hlbWESIi5hdXRoemVkLmFwaS52MS5X",
+            "ZWQuYXBpLnYxLlJlYWRTY2hlbWFSZXNwb25zZSIagtPkkwIUIg8vdjEvc2No",
+            "ZW1hL3JlYWQ6ASoScwoLV3JpdGVTY2hlbWESIi5hdXRoemVkLmFwaS52MS5X",
             "cml0ZVNjaGVtYVJlcXVlc3QaIy5hdXRoemVkLmFwaS52MS5Xcml0ZVNjaGVt",
-            "YVJlc3BvbnNlIhuC0+STAhU6ASoiEC92MS9zY2hlbWEvd3JpdGVCSgoSY29t",
+            "YVJlc3BvbnNlIhuC0+STAhUiEC92MS9zY2hlbWEvd3JpdGU6ASpCSgoSY29t",
             "LmF1dGh6ZWQuYXBpLnYxUAFaMmdpdGh1Yi5jb20vYXV0aHplZC9hdXRoemVk",
             "LWdvL3Byb3RvL2F1dGh6ZWQvYXBpL3YxYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
@@ -57,6 +57,7 @@ namespace Authzed.Api.V1 {
   /// <summary>
   /// ReadSchemaRequest returns the schema from the database.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadSchemaRequest : pb::IMessage<ReadSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -183,7 +184,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -198,7 +203,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -213,6 +222,7 @@ namespace Authzed.Api.V1 {
   /// ReadSchemaResponse is the resulting data after having read the Object
   /// Definitions from a Schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadSchemaResponse : pb::IMessage<ReadSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -406,7 +416,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -432,7 +446,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -458,6 +476,7 @@ namespace Authzed.Api.V1 {
   /// WriteSchemaRequest is the required data used to "upsert" the Schema of a
   /// Permissions System.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WriteSchemaRequest : pb::IMessage<WriteSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -617,7 +636,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -636,7 +659,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -655,6 +682,7 @@ namespace Authzed.Api.V1 {
   /// WriteSchemaResponse is the resulting data after having written a Schema to
   /// a Permissions System.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WriteSchemaResponse : pb::IMessage<WriteSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -816,7 +844,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -838,7 +870,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V1/WatchService.cs
+++ b/src/Authzed.Net/Authzed/Api/V1/WatchService.cs
@@ -25,29 +25,32 @@ namespace Authzed.Api.V1 {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "CiJhdXRoemVkL2FwaS92MS93YXRjaF9zZXJ2aWNlLnByb3RvEg5hdXRoemVk",
-            "LmFwaS52MRocZ29vZ2xlL2FwaS9hbm5vdGF0aW9ucy5wcm90bxoXdmFsaWRh",
-            "dGUvdmFsaWRhdGUucHJvdG8aGWF1dGh6ZWQvYXBpL3YxL2NvcmUucHJvdG8a",
-            "J2F1dGh6ZWQvYXBpL3YxL3Blcm1pc3Npb25fc2VydmljZS5wcm90byLKAgoM",
-            "V2F0Y2hSZXF1ZXN0EoMBChVvcHRpb25hbF9vYmplY3RfdHlwZXMYASADKAlC",
-            "T/pCTJIBSQgAIkVyQyiAATI+XihbYS16XVthLXowLTlfXXsxLDYyfVthLXow",
-            "LTldLykqW2Etel1bYS16MC05X117MSw2Mn1bYS16MC05XSRSE29wdGlvbmFs",
-            "T2JqZWN0VHlwZXMSTAoVb3B0aW9uYWxfc3RhcnRfY3Vyc29yGAIgASgLMhgu",
-            "YXV0aHplZC5hcGkudjEuWmVkVG9rZW5SE29wdGlvbmFsU3RhcnRDdXJzb3IS",
-            "Zgodb3B0aW9uYWxfcmVsYXRpb25zaGlwX2ZpbHRlcnMYAyADKAsyIi5hdXRo",
-            "emVkLmFwaS52MS5SZWxhdGlvbnNoaXBGaWx0ZXJSG29wdGlvbmFsUmVsYXRp",
-            "b25zaGlwRmlsdGVycyKQAQoNV2F0Y2hSZXNwb25zZRI8Cgd1cGRhdGVzGAEg",
-            "AygLMiIuYXV0aHplZC5hcGkudjEuUmVsYXRpb25zaGlwVXBkYXRlUgd1cGRh",
-            "dGVzEkEKD2NoYW5nZXNfdGhyb3VnaBgCIAEoCzIYLmF1dGh6ZWQuYXBpLnYx",
-            "LlplZFRva2VuUg5jaGFuZ2VzVGhyb3VnaDJsCgxXYXRjaFNlcnZpY2USXAoF",
-            "V2F0Y2gSHC5hdXRoemVkLmFwaS52MS5XYXRjaFJlcXVlc3QaHS5hdXRoemVk",
-            "LmFwaS52MS5XYXRjaFJlc3BvbnNlIhSC0+STAg46ASoiCS92MS93YXRjaDAB",
-            "QkoKEmNvbS5hdXRoemVkLmFwaS52MVABWjJnaXRodWIuY29tL2F1dGh6ZWQv",
-            "YXV0aHplZC1nby9wcm90by9hdXRoemVkL2FwaS92MWIGcHJvdG8z"));
+            "LmFwaS52MRocZ29vZ2xlL2FwaS9hbm5vdGF0aW9ucy5wcm90bxocZ29vZ2xl",
+            "L3Byb3RvYnVmL3N0cnVjdC5wcm90bxoXdmFsaWRhdGUvdmFsaWRhdGUucHJv",
+            "dG8aGWF1dGh6ZWQvYXBpL3YxL2NvcmUucHJvdG8aJ2F1dGh6ZWQvYXBpL3Yx",
+            "L3Blcm1pc3Npb25fc2VydmljZS5wcm90byLKAgoMV2F0Y2hSZXF1ZXN0EoMB",
+            "ChVvcHRpb25hbF9vYmplY3RfdHlwZXMYASADKAlCT/pCTJIBSQgAIkVyQyiA",
+            "ATI+XihbYS16XVthLXowLTlfXXsxLDYyfVthLXowLTldLykqW2Etel1bYS16",
+            "MC05X117MSw2Mn1bYS16MC05XSRSE29wdGlvbmFsT2JqZWN0VHlwZXMSTAoV",
+            "b3B0aW9uYWxfc3RhcnRfY3Vyc29yGAIgASgLMhguYXV0aHplZC5hcGkudjEu",
+            "WmVkVG9rZW5SE29wdGlvbmFsU3RhcnRDdXJzb3ISZgodb3B0aW9uYWxfcmVs",
+            "YXRpb25zaGlwX2ZpbHRlcnMYAyADKAsyIi5hdXRoemVkLmFwaS52MS5SZWxh",
+            "dGlvbnNoaXBGaWx0ZXJSG29wdGlvbmFsUmVsYXRpb25zaGlwRmlsdGVycyLt",
+            "AQoNV2F0Y2hSZXNwb25zZRI8Cgd1cGRhdGVzGAEgAygLMiIuYXV0aHplZC5h",
+            "cGkudjEuUmVsYXRpb25zaGlwVXBkYXRlUgd1cGRhdGVzEkEKD2NoYW5nZXNf",
+            "dGhyb3VnaBgCIAEoCzIYLmF1dGh6ZWQuYXBpLnYxLlplZFRva2VuUg5jaGFu",
+            "Z2VzVGhyb3VnaBJbCh1vcHRpb25hbF90cmFuc2FjdGlvbl9tZXRhZGF0YRgD",
+            "IAEoCzIXLmdvb2dsZS5wcm90b2J1Zi5TdHJ1Y3RSG29wdGlvbmFsVHJhbnNh",
+            "Y3Rpb25NZXRhZGF0YTJsCgxXYXRjaFNlcnZpY2USXAoFV2F0Y2gSHC5hdXRo",
+            "emVkLmFwaS52MS5XYXRjaFJlcXVlc3QaHS5hdXRoemVkLmFwaS52MS5XYXRj",
+            "aFJlc3BvbnNlIhSC0+STAg4iCS92MS93YXRjaDoBKjABQkoKEmNvbS5hdXRo",
+            "emVkLmFwaS52MVABWjJnaXRodWIuY29tL2F1dGh6ZWQvYXV0aHplZC1nby9w",
+            "cm90by9hdXRoemVkL2FwaS92MWIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
-          new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, global::Authzed.Api.V1.CoreReflection.Descriptor, global::Authzed.Api.V1.PermissionServiceReflection.Descriptor, },
+          new pbr::FileDescriptor[] { global::Google.Api.AnnotationsReflection.Descriptor, global::Google.Protobuf.WellKnownTypes.StructReflection.Descriptor, global::Validate.ValidateReflection.Descriptor, global::Authzed.Api.V1.CoreReflection.Descriptor, global::Authzed.Api.V1.PermissionServiceReflection.Descriptor, },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.WatchRequest), global::Authzed.Api.V1.WatchRequest.Parser, new[]{ "OptionalObjectTypes", "OptionalStartCursor", "OptionalRelationshipFilters" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.WatchResponse), global::Authzed.Api.V1.WatchResponse.Parser, new[]{ "Updates", "ChangesThrough" }, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Authzed.Api.V1.WatchResponse), global::Authzed.Api.V1.WatchResponse.Parser, new[]{ "Updates", "ChangesThrough", "OptionalTransactionMetadata" }, null, null, null, null)
           }));
     }
     #endregion
@@ -59,6 +62,7 @@ namespace Authzed.Api.V1 {
   /// watching mutations, and an optional start snapshot for when to start
   /// watching.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchRequest : pb::IMessage<WatchRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -274,7 +278,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -304,7 +312,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -336,6 +348,7 @@ namespace Authzed.Api.V1 {
   /// encoded in the watch response. The client can use the snapshot to resume
   /// watching where the previous watch response left off.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchResponse : pb::IMessage<WatchResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -372,6 +385,7 @@ namespace Authzed.Api.V1 {
     public WatchResponse(WatchResponse other) : this() {
       updates_ = other.updates_.Clone();
       changesThrough_ = other.changesThrough_ != null ? other.changesThrough_.Clone() : null;
+      optionalTransactionMetadata_ = other.optionalTransactionMetadata_ != null ? other.optionalTransactionMetadata_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -386,6 +400,10 @@ namespace Authzed.Api.V1 {
     private static readonly pb::FieldCodec<global::Authzed.Api.V1.RelationshipUpdate> _repeated_updates_codec
         = pb::FieldCodec.ForMessage(10, global::Authzed.Api.V1.RelationshipUpdate.Parser);
     private readonly pbc::RepeatedField<global::Authzed.Api.V1.RelationshipUpdate> updates_ = new pbc::RepeatedField<global::Authzed.Api.V1.RelationshipUpdate>();
+    /// <summary>
+    /// updates are the RelationshipUpdate events that have occurred since the
+    /// last watch response.
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public pbc::RepeatedField<global::Authzed.Api.V1.RelationshipUpdate> Updates {
@@ -395,12 +413,34 @@ namespace Authzed.Api.V1 {
     /// <summary>Field number for the "changes_through" field.</summary>
     public const int ChangesThroughFieldNumber = 2;
     private global::Authzed.Api.V1.ZedToken changesThrough_;
+    /// <summary>
+    /// changes_through is the ZedToken that represents the point in time
+    /// that the watch response is current through. This token can be used
+    /// in a subsequent WatchRequest to resume watching from this point.
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public global::Authzed.Api.V1.ZedToken ChangesThrough {
       get { return changesThrough_; }
       set {
         changesThrough_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "optional_transaction_metadata" field.</summary>
+    public const int OptionalTransactionMetadataFieldNumber = 3;
+    private global::Google.Protobuf.WellKnownTypes.Struct optionalTransactionMetadata_;
+    /// <summary>
+    /// optional_transaction_metadata is an optional field that returns the transaction metadata
+    /// given to SpiceDB during the transaction that produced the changes in this response.
+    /// This field may not exist if no transaction metadata was provided.
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.WellKnownTypes.Struct OptionalTransactionMetadata {
+      get { return optionalTransactionMetadata_; }
+      set {
+        optionalTransactionMetadata_ = value;
       }
     }
 
@@ -421,6 +461,7 @@ namespace Authzed.Api.V1 {
       }
       if(!updates_.Equals(other.updates_)) return false;
       if (!object.Equals(ChangesThrough, other.ChangesThrough)) return false;
+      if (!object.Equals(OptionalTransactionMetadata, other.OptionalTransactionMetadata)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -430,6 +471,7 @@ namespace Authzed.Api.V1 {
       int hash = 1;
       hash ^= updates_.GetHashCode();
       if (changesThrough_ != null) hash ^= ChangesThrough.GetHashCode();
+      if (optionalTransactionMetadata_ != null) hash ^= OptionalTransactionMetadata.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -453,6 +495,10 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(18);
         output.WriteMessage(ChangesThrough);
       }
+      if (optionalTransactionMetadata_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(OptionalTransactionMetadata);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -468,6 +514,10 @@ namespace Authzed.Api.V1 {
         output.WriteRawTag(18);
         output.WriteMessage(ChangesThrough);
       }
+      if (optionalTransactionMetadata_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(OptionalTransactionMetadata);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -481,6 +531,9 @@ namespace Authzed.Api.V1 {
       size += updates_.CalculateSize(_repeated_updates_codec);
       if (changesThrough_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(ChangesThrough);
+      }
+      if (optionalTransactionMetadata_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(OptionalTransactionMetadata);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -501,6 +554,12 @@ namespace Authzed.Api.V1 {
         }
         ChangesThrough.MergeFrom(other.ChangesThrough);
       }
+      if (other.optionalTransactionMetadata_ != null) {
+        if (optionalTransactionMetadata_ == null) {
+          OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+        }
+        OptionalTransactionMetadata.MergeFrom(other.OptionalTransactionMetadata);
+      }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -512,7 +571,11 @@ namespace Authzed.Api.V1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -527,6 +590,13 @@ namespace Authzed.Api.V1 {
             input.ReadMessage(ChangesThrough);
             break;
           }
+          case 26: {
+            if (optionalTransactionMetadata_ == null) {
+              OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+            }
+            input.ReadMessage(OptionalTransactionMetadata);
+            break;
+          }
         }
       }
     #endif
@@ -538,7 +608,11 @@ namespace Authzed.Api.V1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -551,6 +625,13 @@ namespace Authzed.Api.V1 {
               ChangesThrough = new global::Authzed.Api.V1.ZedToken();
             }
             input.ReadMessage(ChangesThrough);
+            break;
+          }
+          case 26: {
+            if (optionalTransactionMetadata_ == null) {
+              OptionalTransactionMetadata = new global::Google.Protobuf.WellKnownTypes.Struct();
+            }
+            input.ReadMessage(OptionalTransactionMetadata);
             break;
           }
         }

--- a/src/Authzed.Net/Authzed/Api/V1Alpha1/Schema.cs
+++ b/src/Authzed.Net/Authzed/Api/V1Alpha1/Schema.cs
@@ -64,6 +64,7 @@ namespace Authzed.Api.V1Alpha1 {
   /// ReadSchemaRequest is the required data to read Object Definitions from
   /// a Schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadSchemaRequest : pb::IMessage<ReadSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -214,7 +215,11 @@ namespace Authzed.Api.V1Alpha1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -233,7 +238,11 @@ namespace Authzed.Api.V1Alpha1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -252,6 +261,7 @@ namespace Authzed.Api.V1Alpha1 {
   /// ReadSchemaResponse is the resulting data after having read the Object
   /// Definitions from a Schema.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ReadSchemaResponse : pb::IMessage<ReadSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -431,7 +441,11 @@ namespace Authzed.Api.V1Alpha1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -454,7 +468,11 @@ namespace Authzed.Api.V1Alpha1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -477,6 +495,7 @@ namespace Authzed.Api.V1Alpha1 {
   /// WriteSchemaRequest is the required data used to "upsert" the Schema of a
   /// Permissions System.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WriteSchemaRequest : pb::IMessage<WriteSchemaRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -670,7 +689,11 @@ namespace Authzed.Api.V1Alpha1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -693,7 +716,11 @@ namespace Authzed.Api.V1Alpha1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -716,6 +743,7 @@ namespace Authzed.Api.V1Alpha1 {
   /// WriteSchemaResponse is the resulting data after having written a Schema to
   /// a Permissions System.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WriteSchemaResponse : pb::IMessage<WriteSchemaResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -895,7 +923,11 @@ namespace Authzed.Api.V1Alpha1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -918,7 +950,11 @@ namespace Authzed.Api.V1Alpha1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Authzed/Api/V1Alpha1/WatchresourcesService.cs
+++ b/src/Authzed.Net/Authzed/Api/V1Alpha1/WatchresourcesService.cs
@@ -51,8 +51,8 @@ namespace Authzed.Api.V1Alpha1 {
             "emVkLmFwaS52MS5aZWRUb2tlblIOY2hhbmdlc1Rocm91Z2gyqQEKFVdhdGNo",
             "UmVzb3VyY2VzU2VydmljZRKPAQoOV2F0Y2hSZXNvdXJjZXMSKy5hdXRoemVk",
             "LmFwaS52MWFscGhhMS5XYXRjaFJlc291cmNlc1JlcXVlc3QaLC5hdXRoemVk",
-            "LmFwaS52MWFscGhhMS5XYXRjaFJlc291cmNlc1Jlc3BvbnNlIiCC0+STAho6",
-            "ASoiFS92MWFscGhhMS9sb29rdXB3YXRjaDABQlQKGGNvbS5hdXRoemVkLmFw",
+            "LmFwaS52MWFscGhhMS5XYXRjaFJlc291cmNlc1Jlc3BvbnNlIiCC0+STAhoi",
+            "FS92MWFscGhhMS9sb29rdXB3YXRjaDoBKjABQlQKGGNvbS5hdXRoemVkLmFw",
             "aS52MWFscGhhMVo4Z2l0aHViLmNvbS9hdXRoemVkL2F1dGh6ZWQtZ28vcHJv",
             "dG8vYXV0aHplZC9hcGkvdjFhbHBoYTFiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
@@ -71,6 +71,7 @@ namespace Authzed.Api.V1Alpha1 {
   /// WatchResourcesRequest starts a watch for specific permission updates
   /// for the given resource and subject types.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchResourcesRequest : pb::IMessage<WatchResourcesRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -361,7 +362,11 @@ namespace Authzed.Api.V1Alpha1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -399,7 +404,11 @@ namespace Authzed.Api.V1Alpha1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -437,6 +446,7 @@ namespace Authzed.Api.V1Alpha1 {
   /// PermissionUpdate represents a single permission update for a specific
   /// subject's permissions.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class PermissionUpdate : pb::IMessage<PermissionUpdate>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -691,7 +701,11 @@ namespace Authzed.Api.V1Alpha1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -728,7 +742,11 @@ namespace Authzed.Api.V1Alpha1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -783,6 +801,7 @@ namespace Authzed.Api.V1Alpha1 {
   /// WatchResourcesResponse enumerates the list of permission updates that have
   /// occurred as a result of one or more relationship updates.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class WatchResourcesResponse : pb::IMessage<WatchResourcesResponse>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -959,7 +978,11 @@ namespace Authzed.Api.V1Alpha1 {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -985,7 +1008,11 @@ namespace Authzed.Api.V1Alpha1 {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Google/Api/Http.cs
+++ b/src/Authzed.Net/Google/Api/Http.cs
@@ -57,6 +57,7 @@ namespace Google.Api {
   /// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
   /// to one or more HTTP REST API methods.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Http : pb::IMessage<Http>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -243,7 +244,11 @@ namespace Google.Api {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -266,7 +271,11 @@ namespace Google.Api {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -555,6 +564,7 @@ namespace Google.Api {
   /// the request or response body to a repeated field. However, some gRPC
   /// Transcoding implementations may not support this feature.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class HttpRule : pb::IMessage<HttpRule>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -649,10 +659,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Get {
-      get { return patternCase_ == PatternOneofCase.Get ? (string) pattern_ : ""; }
+      get { return HasGet ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Get;
+      }
+    }
+    /// <summary>Gets whether the "get" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasGet {
+      get { return patternCase_ == PatternOneofCase.Get; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "get" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearGet() {
+      if (HasGet) {
+        ClearPattern();
       }
     }
 
@@ -664,10 +688,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Put {
-      get { return patternCase_ == PatternOneofCase.Put ? (string) pattern_ : ""; }
+      get { return HasPut ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Put;
+      }
+    }
+    /// <summary>Gets whether the "put" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPut {
+      get { return patternCase_ == PatternOneofCase.Put; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "put" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPut() {
+      if (HasPut) {
+        ClearPattern();
       }
     }
 
@@ -679,10 +717,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Post {
-      get { return patternCase_ == PatternOneofCase.Post ? (string) pattern_ : ""; }
+      get { return HasPost ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Post;
+      }
+    }
+    /// <summary>Gets whether the "post" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPost {
+      get { return patternCase_ == PatternOneofCase.Post; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "post" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPost() {
+      if (HasPost) {
+        ClearPattern();
       }
     }
 
@@ -694,10 +746,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Delete {
-      get { return patternCase_ == PatternOneofCase.Delete ? (string) pattern_ : ""; }
+      get { return HasDelete ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Delete;
+      }
+    }
+    /// <summary>Gets whether the "delete" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasDelete {
+      get { return patternCase_ == PatternOneofCase.Delete; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "delete" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearDelete() {
+      if (HasDelete) {
+        ClearPattern();
       }
     }
 
@@ -709,10 +775,24 @@ namespace Google.Api {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public string Patch {
-      get { return patternCase_ == PatternOneofCase.Patch ? (string) pattern_ : ""; }
+      get { return HasPatch ? (string) pattern_ : ""; }
       set {
         pattern_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
         patternCase_ = PatternOneofCase.Patch;
+      }
+    }
+    /// <summary>Gets whether the "patch" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasPatch {
+      get { return patternCase_ == PatternOneofCase.Patch; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "patch" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPatch() {
+      if (HasPatch) {
+        ClearPattern();
       }
     }
 
@@ -849,11 +929,11 @@ namespace Google.Api {
     public override int GetHashCode() {
       int hash = 1;
       if (Selector.Length != 0) hash ^= Selector.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Get) hash ^= Get.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Put) hash ^= Put.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Post) hash ^= Post.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Delete) hash ^= Delete.GetHashCode();
-      if (patternCase_ == PatternOneofCase.Patch) hash ^= Patch.GetHashCode();
+      if (HasGet) hash ^= Get.GetHashCode();
+      if (HasPut) hash ^= Put.GetHashCode();
+      if (HasPost) hash ^= Post.GetHashCode();
+      if (HasDelete) hash ^= Delete.GetHashCode();
+      if (HasPatch) hash ^= Patch.GetHashCode();
       if (patternCase_ == PatternOneofCase.Custom) hash ^= Custom.GetHashCode();
       if (Body.Length != 0) hash ^= Body.GetHashCode();
       if (ResponseBody.Length != 0) hash ^= ResponseBody.GetHashCode();
@@ -881,23 +961,23 @@ namespace Google.Api {
         output.WriteRawTag(10);
         output.WriteString(Selector);
       }
-      if (patternCase_ == PatternOneofCase.Get) {
+      if (HasGet) {
         output.WriteRawTag(18);
         output.WriteString(Get);
       }
-      if (patternCase_ == PatternOneofCase.Put) {
+      if (HasPut) {
         output.WriteRawTag(26);
         output.WriteString(Put);
       }
-      if (patternCase_ == PatternOneofCase.Post) {
+      if (HasPost) {
         output.WriteRawTag(34);
         output.WriteString(Post);
       }
-      if (patternCase_ == PatternOneofCase.Delete) {
+      if (HasDelete) {
         output.WriteRawTag(42);
         output.WriteString(Delete);
       }
-      if (patternCase_ == PatternOneofCase.Patch) {
+      if (HasPatch) {
         output.WriteRawTag(50);
         output.WriteString(Patch);
       }
@@ -928,23 +1008,23 @@ namespace Google.Api {
         output.WriteRawTag(10);
         output.WriteString(Selector);
       }
-      if (patternCase_ == PatternOneofCase.Get) {
+      if (HasGet) {
         output.WriteRawTag(18);
         output.WriteString(Get);
       }
-      if (patternCase_ == PatternOneofCase.Put) {
+      if (HasPut) {
         output.WriteRawTag(26);
         output.WriteString(Put);
       }
-      if (patternCase_ == PatternOneofCase.Post) {
+      if (HasPost) {
         output.WriteRawTag(34);
         output.WriteString(Post);
       }
-      if (patternCase_ == PatternOneofCase.Delete) {
+      if (HasDelete) {
         output.WriteRawTag(42);
         output.WriteString(Delete);
       }
-      if (patternCase_ == PatternOneofCase.Patch) {
+      if (HasPatch) {
         output.WriteRawTag(50);
         output.WriteString(Patch);
       }
@@ -974,19 +1054,19 @@ namespace Google.Api {
       if (Selector.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Selector);
       }
-      if (patternCase_ == PatternOneofCase.Get) {
+      if (HasGet) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Get);
       }
-      if (patternCase_ == PatternOneofCase.Put) {
+      if (HasPut) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Put);
       }
-      if (patternCase_ == PatternOneofCase.Post) {
+      if (HasPost) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Post);
       }
-      if (patternCase_ == PatternOneofCase.Delete) {
+      if (HasDelete) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Delete);
       }
-      if (patternCase_ == PatternOneofCase.Patch) {
+      if (HasPatch) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Patch);
       }
       if (patternCase_ == PatternOneofCase.Custom) {
@@ -1056,7 +1136,11 @@ namespace Google.Api {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1116,7 +1200,11 @@ namespace Google.Api {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1175,6 +1263,7 @@ namespace Google.Api {
   /// <summary>
   /// A custom pattern is used for defining custom HTTP verb.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class CustomHttpPattern : pb::IMessage<CustomHttpPattern>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1365,7 +1454,11 @@ namespace Google.Api {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1388,7 +1481,11 @@ namespace Google.Api {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Google/Rpc/Status.cs
+++ b/src/Authzed.Net/Google/Rpc/Status.cs
@@ -50,6 +50,7 @@ namespace Google.Rpc {
   /// You can find out more about this error model and how to work with it in the
   /// [API Design Guide](https://cloud.google.com/apis/design/errors).
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Status : pb::IMessage<Status>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -264,7 +265,11 @@ namespace Google.Rpc {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -291,7 +296,11 @@ namespace Google.Rpc {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Grpc/Gateway/ProtocGenOpenapiv2/Options/Openapiv2.cs
+++ b/src/Authzed.Net/Grpc/Gateway/ProtocGenOpenapiv2/Options/Openapiv2.cs
@@ -253,6 +253,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///    produces: "application/json";
   ///  };
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Swagger : pb::IMessage<Swagger>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -701,7 +702,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       schemes_.Add(other.schemes_);
       consumes_.Add(other.consumes_);
       produces_.Add(other.produces_);
-      responses_.Add(other.responses_);
+      responses_.MergeFrom(other.responses_);
       if (other.securityDefinitions_ != null) {
         if (securityDefinitions_ == null) {
           SecurityDefinitions = new global::Grpc.Gateway.ProtocGenOpenapiv2.Options.SecurityDefinitions();
@@ -715,7 +716,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         ExternalDocs.MergeFrom(other.ExternalDocs);
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -727,7 +728,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -800,7 +805,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -896,6 +905,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///    }
   ///  }
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Operation : pb::IMessage<Operation>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1329,13 +1339,13 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       }
       consumes_.Add(other.consumes_);
       produces_.Add(other.produces_);
-      responses_.Add(other.responses_);
+      responses_.MergeFrom(other.responses_);
       schemes_.Add(other.schemes_);
       if (other.Deprecated != false) {
         Deprecated = other.Deprecated;
       }
       security_.Add(other.security_);
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -1347,7 +1357,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1414,7 +1428,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1482,6 +1500,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///
   /// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#headerObject
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Header : pb::IMessage<Header>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1770,7 +1789,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1805,7 +1828,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1841,6 +1868,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///
   /// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#responseObject
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Response : pb::IMessage<Response>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2085,9 +2113,9 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         Schema.MergeFrom(other.Schema);
       }
-      headers_.Add(other.headers_);
-      examples_.Add(other.examples_);
-      extensions_.Add(other.extensions_);
+      headers_.MergeFrom(other.headers_);
+      examples_.MergeFrom(other.examples_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -2099,7 +2127,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2137,7 +2169,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2196,6 +2232,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///    ...
   ///  };
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Info : pb::IMessage<Info>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2528,7 +2565,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other.Version.Length != 0) {
         Version = other.Version;
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -2540,7 +2577,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2589,7 +2630,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2654,6 +2699,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///    ...
   ///  };
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Contact : pb::IMessage<Contact>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2878,7 +2924,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2905,7 +2955,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2947,6 +3001,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///    ...
   ///  };
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class License : pb::IMessage<License>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3137,7 +3192,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3160,7 +3219,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3196,6 +3259,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///    ...
   ///  };
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ExternalDocumentation : pb::IMessage<ExternalDocumentation>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3388,7 +3452,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3411,7 +3479,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3435,6 +3507,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///
   /// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#schemaObject
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Schema : pb::IMessage<Schema>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3733,7 +3806,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3774,7 +3851,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3840,6 +3921,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///        }];
   ///  }
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class JSONSchema : pb::IMessage<JSONSchema>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4695,7 +4777,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         FieldConfiguration.MergeFrom(other.FieldConfiguration);
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -4707,7 +4789,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4830,7 +4916,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4967,6 +5057,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       /// 'FieldConfiguration' provides additional field level properties used when generating the OpenAPI v2 file.
       /// These properties are not defined by OpenAPIv2, but they are used to control the generation.
       /// </summary>
+      [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
       public sealed partial class FieldConfiguration : pb::IMessage<FieldConfiguration>
       #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
           , pb::IBufferMessage
@@ -5128,7 +5219,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         #else
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
@@ -5147,7 +5242,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
                 break;
@@ -5172,6 +5271,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///
   /// See: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/2.0.md#tagObject
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Tag : pb::IMessage<Tag>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5366,7 +5466,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5392,7 +5496,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5424,6 +5532,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   /// specification. This does not enforce the security schemes on the operations
   /// and only serves to provide the relevant details for each scheme.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SecurityDefinitions : pb::IMessage<SecurityDefinitions>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5560,7 +5669,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other == null) {
         return;
       }
-      security_.Add(other.security_);
+      security_.MergeFrom(other.security_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -5572,7 +5681,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5591,7 +5704,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5617,6 +5734,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   /// a header or as a query parameter) and OAuth2's common flows (implicit,
   /// password, application and access code).
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SecurityScheme : pb::IMessage<SecurityScheme>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6019,7 +6137,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         }
         Scopes.MergeFrom(other.Scopes);
       }
-      extensions_.Add(other.extensions_);
+      extensions_.MergeFrom(other.extensions_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -6031,7 +6149,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6085,7 +6207,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6188,6 +6314,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   /// The name used for each property MUST correspond to a security scheme
   /// declared in the Security Definitions.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SecurityRequirement : pb::IMessage<SecurityRequirement>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6326,7 +6453,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other == null) {
         return;
       }
-      securityRequirement_.Add(other.securityRequirement_);
+      securityRequirement_.MergeFrom(other.securityRequirement_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -6338,7 +6465,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6357,7 +6488,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6380,6 +6515,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       /// scope names required for the execution. For other security scheme types,
       /// the array MUST be empty.
       /// </summary>
+      [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
       public sealed partial class SecurityRequirementValue : pb::IMessage<SecurityRequirementValue>
       #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
           , pb::IBufferMessage
@@ -6524,7 +6660,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         #else
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
                 break;
@@ -6543,7 +6683,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
         void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
           uint tag;
           while ((tag = input.ReadTag()) != 0) {
-            switch(tag) {
+          if ((tag & 7) == 4) {
+            // Abort on any end group tag.
+            return;
+          }
+          switch(tag) {
               default:
                 _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
                 break;
@@ -6570,6 +6714,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
   ///
   /// Lists the available scopes for an OAuth2 security scheme.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Scopes : pb::IMessage<Scopes>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6706,7 +6851,7 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
       if (other == null) {
         return;
       }
-      scope_.Add(other.scope_);
+      scope_.MergeFrom(other.scope_);
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
 
@@ -6718,7 +6863,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6737,7 +6886,11 @@ namespace Grpc.Gateway.ProtocGenOpenapiv2.Options {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;

--- a/src/Authzed.Net/Validate/Validate.cs
+++ b/src/Authzed.Net/Validate/Validate.cs
@@ -246,6 +246,7 @@ namespace Validate {
   /// FieldRules encapsulates the rules for each type of field. Depending on the
   /// field, the correct set should be used to ensure proper validations.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class FieldRules : pb::IMessage<FieldRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -1175,7 +1176,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -1386,7 +1391,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -1596,6 +1605,7 @@ namespace Validate {
   /// <summary>
   /// FloatRules describes the constraints applied to `float` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class FloatRules : pb::IMessage<FloatRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2057,7 +2067,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2106,7 +2120,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2154,6 +2172,7 @@ namespace Validate {
   /// <summary>
   /// DoubleRules describes the constraints applied to `double` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DoubleRules : pb::IMessage<DoubleRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -2615,7 +2634,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -2664,7 +2687,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -2712,6 +2739,7 @@ namespace Validate {
   /// <summary>
   /// Int32Rules describes the constraints applied to `int32` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Int32Rules : pb::IMessage<Int32Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3173,7 +3201,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3222,7 +3254,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3270,6 +3306,7 @@ namespace Validate {
   /// <summary>
   /// Int64Rules describes the constraints applied to `int64` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Int64Rules : pb::IMessage<Int64Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -3731,7 +3768,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -3780,7 +3821,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -3828,6 +3873,7 @@ namespace Validate {
   /// <summary>
   /// UInt32Rules describes the constraints applied to `uint32` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UInt32Rules : pb::IMessage<UInt32Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4289,7 +4335,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4338,7 +4388,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4386,6 +4440,7 @@ namespace Validate {
   /// <summary>
   /// UInt64Rules describes the constraints applied to `uint64` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class UInt64Rules : pb::IMessage<UInt64Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4847,7 +4902,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -4896,7 +4955,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -4944,6 +5007,7 @@ namespace Validate {
   /// <summary>
   /// SInt32Rules describes the constraints applied to `sint32` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SInt32Rules : pb::IMessage<SInt32Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5405,7 +5469,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -5454,7 +5522,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -5502,6 +5574,7 @@ namespace Validate {
   /// <summary>
   /// SInt64Rules describes the constraints applied to `sint64` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SInt64Rules : pb::IMessage<SInt64Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -5963,7 +6036,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6012,7 +6089,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6060,6 +6141,7 @@ namespace Validate {
   /// <summary>
   /// Fixed32Rules describes the constraints applied to `fixed32` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Fixed32Rules : pb::IMessage<Fixed32Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6521,7 +6603,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -6570,7 +6656,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -6618,6 +6708,7 @@ namespace Validate {
   /// <summary>
   /// Fixed64Rules describes the constraints applied to `fixed64` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Fixed64Rules : pb::IMessage<Fixed64Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7079,7 +7170,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -7128,7 +7223,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7176,6 +7275,7 @@ namespace Validate {
   /// <summary>
   /// SFixed32Rules describes the constraints applied to `sfixed32` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SFixed32Rules : pb::IMessage<SFixed32Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7637,7 +7737,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -7686,7 +7790,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -7734,6 +7842,7 @@ namespace Validate {
   /// <summary>
   /// SFixed64Rules describes the constraints applied to `sfixed64` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class SFixed64Rules : pb::IMessage<SFixed64Rules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8195,7 +8304,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8244,7 +8357,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8292,6 +8409,7 @@ namespace Validate {
   /// <summary>
   /// BoolRules describes the constraints applied to `bool` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BoolRules : pb::IMessage<BoolRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8467,7 +8585,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -8486,7 +8608,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -8504,6 +8630,7 @@ namespace Validate {
   /// <summary>
   /// StringRules describe the constraints applied to `string` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class StringRules : pb::IMessage<StringRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -9874,7 +10001,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -9994,7 +10125,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -10113,6 +10248,7 @@ namespace Validate {
   /// <summary>
   /// BytesRules describe the constraints applied to `bytes` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class BytesRules : pb::IMessage<BytesRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -10888,7 +11024,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -10959,7 +11099,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -11029,6 +11173,7 @@ namespace Validate {
   /// <summary>
   /// EnumRules describe the constraints applied to enum values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class EnumRules : pb::IMessage<EnumRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -11296,7 +11441,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -11329,7 +11478,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -11362,6 +11515,7 @@ namespace Validate {
   /// MessageRules describe the constraints applied to embedded message values.
   /// For message-type fields, validation is performed recursively.
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class MessageRules : pb::IMessage<MessageRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -11585,7 +11739,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -11608,7 +11766,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -11630,6 +11792,7 @@ namespace Validate {
   /// <summary>
   /// RepeatedRules describe the constraints applied to `repeated` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RepeatedRules : pb::IMessage<RepeatedRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -11988,7 +12151,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -12026,7 +12193,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -12063,6 +12234,7 @@ namespace Validate {
   /// <summary>
   /// MapRules describe the constraints applied to `map` values
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class MapRules : pb::IMessage<MapRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -12455,7 +12627,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -12500,7 +12676,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -12545,6 +12725,7 @@ namespace Validate {
   /// AnyRules describe constraints applied exclusively to the
   /// `google.protobuf.Any` well-known type
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class AnyRules : pb::IMessage<AnyRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -12764,7 +12945,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -12791,7 +12976,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -12818,6 +13007,7 @@ namespace Validate {
   /// DurationRules describe the constraints applied exclusively to the
   /// `google.protobuf.Duration` well-known type
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class DurationRules : pb::IMessage<DurationRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -13216,7 +13406,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -13278,7 +13472,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
@@ -13340,6 +13538,7 @@ namespace Validate {
   /// TimestampRules describe the constraints applied exclusively to the
   /// `google.protobuf.Timestamp` well-known type
   /// </summary>
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class TimestampRules : pb::IMessage<TimestampRules>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -13827,7 +14026,11 @@ namespace Validate {
     #else
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
@@ -13896,7 +14099,11 @@ namespace Validate {
     void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
       uint tag;
       while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;


### PR DESCRIPTION
## Description
Part of bringing in 1.38.0. Also converts the lib to use remote plugins, which allows us to use the automatic version bumping workflows.

## Changes
* Bump API version to 1.38.0
* Use buf remote plugins
* Regenerate lib with above
* Add workflows for version bumping

## Testing
Review. See that tests are green.