### PR TITLE
Add draft behavior to PR creation

### DIFF
--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -1,3 +1,4 @@
+---
 name: "Called update for API change"
 on:
   repository_dispatch:
@@ -36,6 +37,9 @@ jobs:
         with:
           delete-branch: "true"
           title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          # This is how we ensure that workflows run
+          draft: "always-true"
           branch: "api-change/${{ github.event.client_payload.BUFTAG }}"
           base: "main"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -40,6 +40,9 @@ jobs:
         if: steps.buf-update.outputs.updated == 'true'
         with:
           delete-branch: "true"
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          # This is how we ensure that workflows run
+          draft: "always-true"
           title: Update API to ${{ inputs.buftag }}
           branch: api-change/${{ inputs.buftag }}
           base: "main"


### PR DESCRIPTION
## Description
This is partially just to have opened a PR on this repo to check the current workflow status. It will also mean that future PRs created by our automation should have checks run against them.

## Changes
* Make the created PRs open as draft
## Testing
Review.