### PR TITLE
chore: add conventional commit linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     groups:
       dotnet:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -15,3 +19,7 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"

--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Called update for API change"
-on:
+on:  # yamllint disable-line rule:truthy
   repository_dispatch:
     types: ["api_update"]
 jobs:
@@ -37,6 +37,7 @@ jobs:
         with:
           delete-branch: "true"
           title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          commit-message: "feat: update api version"
           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
           # This is how we ensure that workflows run
           draft: "always-true"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,11 +8,11 @@ on:  # yamllint disable-line rule:truthy
     branches: ["*"]
     types:
       # NOTE: these are the defaults
-      - opened
-      - synchronize
-      - reopened
+      - "opened"
+      - "synchronize"
+      - "reopened"
       # NOTE: we add this to let the conversion from draft trigger the workflows
-      - ready_for_review
+      - "ready_for_review"
 jobs:
   lint:
     # Uses pre-commit to run all checks
@@ -26,4 +26,11 @@ jobs:
       - uses: "actions/setup-dotnet@v5"
         with:
           dotnet-version: '8.x'
-      - uses: "pre-commit/action@v3.0.1"
+      - uses: "j178/prek-action@v1"
+
+  conventional-commits:
+    name: "Lint Commit Messages"
+    runs-on: "depot-ubuntu-24.04-small"
+    steps:
+      - uses: "actions/checkout@v5"
+      - uses: "webiny/action-conventional-commits@v1.3.0"

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -1,6 +1,6 @@
 ---
 name: Update for API change
-on:
+on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       buftag:
@@ -43,7 +43,8 @@ jobs:
           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
           # This is how we ensure that workflows run
           draft: "always-true"
-          title: Update API to ${{ inputs.buftag }}
-          branch: api-change/${{ inputs.buftag }}
+          title: "Update API to ${{ inputs.buftag }}"
+          commit-message: "feat: update api version"
+          branch: "api-change/${{ inputs.buftag }}"
           base: "main"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Description
Part of preparing this repo for the use of `release-please`. We need to have conventional commits in place, so this adds a linter for that and does some other drive-by refactors to workflows.

## Changes
* Add conventional commit linting
* Make the `create-pull-request` action tag with a conventional commit (`feat` to trigger a release)
* Ensure that dependabot uses conventional commits
* Some drive-by refactors

## Testing
Review. See that tests pass.